### PR TITLE
feat: add project name and build time to version output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build all platforms
         run: |
-          ./build.sh --all --version "${{ github.ref_name }}"
+          ./build.sh --all --version "${{ github.ref_name }}" --build-time "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ PLATFORMS=()
 OUTPUT_DIR="dist"
 BINARY_NAME="ccc"
 VERSION=""
+BUILD_TIME=""
 
 # Available platforms (using plain variables for bash compatibility)
 PLATFORMS_INFO=(
@@ -35,6 +36,7 @@ print_help() {
     echo "  -o, --output        Output directory (default: dist)"
     echo "  -n, --name          Binary name (default: ccc)"
     echo "  -v, --version       Version string (default: git commit short hash)"
+    echo "  -t, --build-time    Build time in ISO 8601 format (default: current UTC time)"
     echo "  -h, --help          Show this help message"
     echo ""
     echo "Examples:"
@@ -75,6 +77,9 @@ build_platform() {
     if [ -n "$VERSION" ]; then
         ldflags="$ldflags -X main.Version=${VERSION}"
     fi
+    if [ -n "$BUILD_TIME" ]; then
+        ldflags="$ldflags -X main.BuildTime=${BUILD_TIME}"
+    fi
     CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" go build -ldflags="$ldflags" -o "${output_path}" main.go
 
     # Make executable (not needed for Windows)
@@ -108,6 +113,10 @@ while [[ $# -gt 0 ]]; do
             VERSION="$2"
             shift 2
             ;;
+        -t|--build-time)
+            BUILD_TIME="$2"
+            shift 2
+            ;;
         -h|--help)
             print_help
             exit 0
@@ -130,6 +139,14 @@ if [ -z "$VERSION" ]; then
     echo -e "${YELLOW}Version: ${BLUE}${VERSION}${NC} (auto-detected from git)"
 else
     echo -e "${YELLOW}Version: ${BLUE}${VERSION}${NC}"
+fi
+
+# Set default build time if not specified
+if [ -z "$BUILD_TIME" ]; then
+    BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo -e "${YELLOW}Build time: ${BLUE}${BUILD_TIME}${NC} (auto-generated)"
+else
+    echo -e "${YELLOW}Build time: ${BLUE}${BUILD_TIME}${NC}"
 fi
 echo ""
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,12 @@ import (
 // Version is set by build flags during release
 var Version = "dev"
 
+// Name is the project name (fixed string)
+var Name = "claude-code-config-switcher"
+
+// BuildTime is set by build flags during release (ISO 8601 format)
+var BuildTime = "unknown"
+
 // getClaudeDirFunc is a variable that holds the function to get the Claude directory
 // This allows tests to override it for testing purposes
 var getClaudeDirFunc = func() string {
@@ -372,7 +378,7 @@ func main() {
 
 	// Handle --version
 	if len(args) == 1 && (args[0] == "--version" || args[0] == "-v") {
-		fmt.Printf("ccc version %s\n", Version)
+		fmt.Printf("%s version %s (built at %s)\n", Name, Version, BuildTime)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Summary
- Add project name (`claude-code-config-switcher`) to `--version` output
- Add build timestamp in ISO 8601 format to `--version` output
- Update `build.sh` to inject build time during compilation
- Update release CI to pass build time to build script

## Changes
- `main.go`: Add `Name` and `BuildTime` variables, update version output format
- `build.sh`: Add `--build-time` parameter and auto-generate UTC timestamp
- `.github/workflows/release.yml`: Pass build time to build script

## Output format
Before: `ccc version 24186d1`
After: `claude-code-config-switcher version 24186d1 (built at 2025-12-28T07:20:23Z)`