### PR TITLE
feat: add claude_args configuration for fixed command-line arguments

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -75,6 +75,7 @@ $os = "windows"; $arch = if ([Environment]::Is64BitProcess) { "amd64" } else { t
       "DISABLE_COST_WARNINGS": "1"
     }
   },
+  "claude_args": ["--verbose", "--debug"],
   "current_provider": "kimi",
   "providers": {
     "kimi": {
@@ -107,6 +108,7 @@ $os = "windows"; $arch = if ([Environment]::Is64BitProcess) { "amd64" } else { t
 
 **配置结构：**
 - `settings` — 所有提供商共享的基础模板
+- `claude_args` — 固定传递给 Claude Code 的参数（可选）
 - `current_provider` — 最后使用的提供商（自动更新）
 - `providers` — 提供商特定配置
 
@@ -138,6 +140,11 @@ ccc validate --all
 # 传递参数给 Claude Code
 ccc kimi --help
 ccc kimi /path/to/project
+```
+
+**说明：** `claude_args` 中配置的参数会自动添加到任何命令行参数之前。例如，如果 `claude_args` 配置为 `["--verbose", "--debug"]`，执行 `ccc kimi --help` 时实际运行的命令是：
+```bash
+claude --settings ~/.claude/settings-kimi.json --verbose --debug --help
 ```
 
 ### 配置验证命令

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Create `~/.claude/ccc.json`:
       "DISABLE_COST_WARNINGS": "1"
     }
   },
+  "claude_args": ["--verbose", "--debug"],
   "current_provider": "kimi",
   "providers": {
     "kimi": {
@@ -107,6 +108,7 @@ Create `~/.claude/ccc.json`:
 
 **Config structure:**
 - `settings` — Base template shared by all providers
+- `claude_args` — Fixed arguments to pass to Claude Code (optional)
 - `current_provider` — Last used provider (auto-updated)
 - `providers` — Provider-specific overrides
 
@@ -155,6 +157,11 @@ ccc validate --all
 # Pass arguments to Claude Code
 ccc kimi --help
 ccc kimi /path/to/project
+```
+
+**Note:** Arguments configured in `claude_args` are automatically prepended to any command-line arguments. For example, if `claude_args` is `["--verbose", "--debug"]` and you run `ccc kimi --help`, the actual command will be:
+```bash
+claude --settings ~/.claude/settings-kimi.json --verbose --debug --help
 ```
 
 ### Validation Command

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ func GetDir() string {
 // Settings and Providers use dynamic maps to handle arbitrary Claude settings fields.
 type Config struct {
 	Settings        map[string]interface{}            `json:"settings"`
+	ClaudeArgs      []string                          `json:"claude_args,omitempty"`
 	CurrentProvider string                            `json:"current_provider"`
 	Providers       map[string]map[string]interface{} `json:"providers"`
 }


### PR DESCRIPTION
## Summary
- Add `claude_args` field to ccc.json configuration
- Allows users to specify fixed command-line arguments (e.g., `--verbose --debug`)
- Arguments are automatically prepended to all Claude Code launches

## Test plan
- [x] All existing tests pass
- [x] Manual verification: configured args are merged with command-line args