### PR TITLE
feat: clear env in settings.json to prevent configuration pollution

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Switch switches to the specified provider by merging configurations.
-// It saves the merged settings and updates the current provider in ccc.json.
+// It saves the merged settings to settings-{provider}.json, clears env in settings.json,
+// and updates the current provider in ccc.json.
 func Switch(cfg *config.Config, providerName string) (map[string]interface{}, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
@@ -28,6 +29,15 @@ func Switch(cfg *config.Config, providerName string) (map[string]interface{}, er
 	// Save the merged settings to settings-{provider}.json
 	if err := config.SaveSettings(mergedSettings, providerName); err != nil {
 		return nil, fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	// Clear env field in settings.json to prevent configuration pollution
+	cleared, err := config.ClearEnvInSettings()
+	if err != nil {
+		return nil, fmt.Errorf("failed to clear env in settings.json: %w", err)
+	}
+	if cleared {
+		fmt.Println("Cleared env field in settings.json to prevent configuration pollution")
 	}
 
 	// Update current_provider in ccc.json

--- a/openspec/changes/clear-env-pollution/proposal.md
+++ b/openspec/changes/clear-env-pollution/proposal.md
@@ -1,0 +1,22 @@
+# Change: 防止 settings.json 中的 env 配置污染提供商配置
+
+## Why
+
+Claude Code 启动时会按 `--setting-sources`（默认：user,project,local）顺序加载配置。其中 user 源会加载 `~/.claude/settings.json`，即使使用 `--settings` 参数指定了其他配置文件，settings.json 仍然会被合并。
+
+这导致 ccc 切换提供商时，settings.json 中的 env 配置（如 API key、model 等）会被加载并污染提供商特定的配置，使得切换提供商后实际使用的配置与预期不符。
+
+## What Changes
+
+- 在切换提供商时，清空 `~/.claude/settings.json` 中的 `env` 字段
+- 添加 `ClearEnvInSettings()` 辅助函数到 config 包
+- 在 `provider.Switch()` 中调用清空函数，并在清空时输出提示信息
+- 保持现有文件结构不变（仍使用 `settings-{provider}.json` + `--settings`）
+
+## Impact
+
+- Affected specs: `provider-management`, `core-config`
+- Affected code:
+  - `internal/config/config.go` - 新增 `ClearEnvInSettings()` 函数
+  - `internal/provider/provider.go` - 修改 `Switch()` 函数调用清空逻辑
+  - `internal/cli/cli.go` - 无需修改（保持 --settings 参数）

--- a/openspec/changes/clear-env-pollution/specs/core-config/spec.md
+++ b/openspec/changes/clear-env-pollution/specs/core-config/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: settings.json 路径获取
+
+系统 SHALL 提供获取 `~/.claude/settings.json` 路径的函数。
+
+#### Scenario: 默认路径
+- **WHEN** 未设置 CCC_CONFIG_DIR 环境变量
+- **THEN** 应当返回 `~/.claude/settings.json`
+
+#### Scenario: 自定义路径
+- **GIVEN** CCC_CONFIG_DIR 设置为 `/custom/path`
+- **WHEN** 调用 `GetSettingsJSONPath()`
+- **THEN** 应当返回 `/custom/path/settings.json`
+
+### Requirement: 清空 settings.json 中的 env 字段
+
+系统 SHALL 能够清空 `~/.claude/settings.json` 中的 `env` 字段，保留其他配置不变。
+
+#### Scenario: 成功清空 env 字段
+- **GIVEN** `~/.claude/settings.json` 包含 `{"permissions": {...}, "env": {"API_KEY": "xxx"}}`
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 文件内容应当变为 `{"permissions": {...}, "env": {}}`
+- **AND** 应当返回 true
+- **AND** error 应当为 nil
+
+#### Scenario: settings.json 不存在
+- **GIVEN** `~/.claude/settings.json` 不存在
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 不应创建文件
+- **AND** 应当返回 false
+- **AND** error 应当为 nil
+
+#### Scenario: settings.json 格式错误
+- **GIVEN** `~/.claude/settings.json` 包含无效的 JSON
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 应当返回错误
+- **AND** 错误信息应当包含 "failed to parse settings.json"
+
+#### Scenario: 无 env 字段
+- **GIVEN** `~/.claude/settings.json` 包含 `{"permissions": {...}}`（无 env 字段）
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 文件内容不应改变
+- **AND** 应当返回 false
+- **AND** error 应当为 nil

--- a/openspec/changes/clear-env-pollution/specs/provider-management/spec.md
+++ b/openspec/changes/clear-env-pollution/specs/provider-management/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: 提供商切换
+
+系统 SHALL 能够切换到指定的提供商，包括配置合并和文件保存。切换时应当清空 settings.json 中的 env 字段以防止配置污染。
+
+#### Scenario: 切换到存在的提供商
+- **GIVEN** 配置中存在提供商 "kimi"
+- **AND** `~/.claude/settings.json` 存在且包含 `env` 字段
+- **WHEN** 调用 `Switch(config, "kimi")`
+- **THEN** 应当合并 settings 和 kimi 提供商配置
+- **AND** 应当保存到 `settings-kimi.json`
+- **AND** 应当将 settings.json 中的 env 字段清空为 `{}`
+- **AND** 应当输出提示信息 "Cleared env field in settings.json to prevent configuration pollution"
+- **AND** 应当更新 current_provider 为 "kimi"
+- **AND** 应当返回合并后的配置
+
+#### Scenario: 切换到存在的提供商（settings.json 无 env）
+- **GIVEN** 配置中存在提供商 "kimi"
+- **AND** `~/.claude/settings.json` 不存在或没有 `env` 字段
+- **WHEN** 调用 `Switch(config, "kimi")`
+- **THEN** 应当合并 settings 和 kimi 提供商配置
+- **AND** 应当保存到 `settings-kimi.json`
+- **AND** 不应输出任何关于清空 env 的提示
+- **AND** 应当更新 current_provider 为 "kimi"
+- **AND** 应当返回合并后的配置
+
+#### Scenario: 切换到不存在的提供商
+- **GIVEN** 配置中不存在提供商 "unknown"
+- **WHEN** 调用 `Switch(config, "unknown")`
+- **THEN** 应当返回错误
+- **AND** 错误信息应当包含 "provider 'unknown' not found"
+
+## ADDED Requirements
+
+### Requirement: 清空 settings.json 中的 env 字段
+
+系统 SHALL 能够清空 `~/.claude/settings.json` 中的 `env` 字段，以防止它污染提供商特定的配置。
+
+#### Scenario: settings.json 存在且包含 env 字段
+- **GIVEN** `~/.claude/settings.json` 存在
+- **AND** 文件包含 `{"env": {"ANTHROPIC_AUTH_TOKEN": "sk-old"}}`
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 应当将 env 字段设置为空对象 `{}`
+- **AND** 应当保留其他字段（如 permissions、alwaysThinkingEnabled）
+- **AND** 应当返回 true 表示已清空
+
+#### Scenario: settings.json 不存在
+- **GIVEN** `~/.claude/settings.json` 不存在
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 不应创建文件
+- **AND** 应当返回 false 表示未清空
+
+#### Scenario: settings.json 存在但没有 env 字段
+- **GIVEN** `~/.claude/settings.json` 存在
+- **AND** 文件不包含 `env` 字段
+- **WHEN** 调用 `ClearEnvInSettings()`
+- **THEN** 文件内容不应改变
+- **AND** 应当返回 false 表示未清空

--- a/openspec/changes/clear-env-pollution/tasks.md
+++ b/openspec/changes/clear-env-pollution/tasks.md
@@ -1,0 +1,27 @@
+## 1. 实现 ClearEnvInSettings 函数
+
+- [x] 1.1 在 `internal/config/config.go` 中添加 `GetSettingsJSONPath()` 函数
+- [x] 1.2 实现 `ClearEnvInSettings()` 函数
+  - 读取 `~/.claude/settings.json`
+  - 检查是否存在 `env` 字段
+  - 如果存在，将 `env` 设置为空对象 `{}`
+  - 写回文件
+  - 返回是否清空了 env（bool）和可能的错误
+
+## 2. 修改 provider.Switch 逻辑
+
+- [x] 2.1 在 `provider.Switch()` 中，先写入 `settings-{provider}.json`
+- [x] 2.2 然后调用 `config.ClearEnvInSettings()`
+- [x] 2.3 如果清空了 env，输出提示信息："Cleared env field in settings.json to prevent configuration pollution"
+
+## 3. 测试
+
+- [x] 3.1 为 `ClearEnvInSettings()` 添加单元测试
+- [x] 3.2 更新 `provider.Switch()` 的测试以验证清空逻辑
+- [x] 3.3 运行完整测试套件确保无回归
+
+## 4. 代码质量检查
+
+- [x] 4.1 运行 `go test ./... -race` 验证无竞态条件
+- [x] 4.2 运行 `gofmt -l .` 检查格式
+- [x] 4.3 运行 `go vet ./...` 进行静态检查


### PR DESCRIPTION
## Summary

- Add `ClearEnvInSettings()` function to clear env field in `~/.claude/settings.json`
- Modify `provider.Switch()` to clear env after writing provider config
- Add unit tests for the new functionality

## Problem

Claude Code loads `~/.claude/settings.json` (user config source) even when using `--settings` parameter. This causes env configuration from settings.json to pollute the provider-specific configuration, making provider switching ineffective.

## Solution

When switching providers:
1. Write merged config to `settings-{provider}.json` (existing behavior)
2. Clear the `env` field in `settings.json` to prevent pollution
3. Output a message when env is cleared

This preserves other settings (permissions, thinking mode, etc.) in settings.json while isolating the provider-specific env configuration.

## Test plan

- [x] Unit tests for `ClearEnvInSettings()` covering:
  - settings.json exists with env field
  - settings.json does not exist
  - settings.json exists without env field
  - settings.json has invalid JSON
- [x] All existing tests pass
- [x] No race conditions detected
- [x] Code formatting and static checks pass