### PR TITLE
fix: only show env cleared message when env was actually non-empty

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -231,10 +231,16 @@ func ClearEnvInSettings() (bool, error) {
 		return false, fmt.Errorf("failed to parse settings.json: %w", err)
 	}
 
-	// Check if env field exists
-	_, hasEnv := settings["env"]
+	// Check if env field exists and is non-empty
+	envField, hasEnv := settings["env"]
 	if !hasEnv {
 		// No env field to clear
+		return false, nil
+	}
+
+	// Check if env is already empty
+	if envMap, ok := envField.(map[string]interface{}); ok && len(envMap) == 0 {
+		// env field exists but is already empty, no need to clear
 		return false, nil
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -763,6 +763,36 @@ func TestClearEnvInSettings(t *testing.T) {
 		compareJSON(t, loaded, originalSettings)
 	})
 
+	t.Run("settings.json exists with empty env field", func(t *testing.T) {
+		tmpDir, cleanup := setupTestDir(t)
+		defer cleanup()
+
+		// Create settings.json with empty env field
+		settingsPath := filepath.Join(tmpDir, "settings.json")
+		originalSettings := map[string]interface{}{
+			"permissions": map[string]interface{}{
+				"allow": []interface{}{"Edit"},
+			},
+			"alwaysThinkingEnabled": true,
+			"env":                   map[string]interface{}{},
+		}
+		writeJSONFile(t, settingsPath, originalSettings)
+
+		// Try to clear env - should return false since env is already empty
+		cleared, err := ClearEnvInSettings()
+		if err != nil {
+			t.Fatalf("ClearEnvInSettings() error = %v", err)
+		}
+		if cleared {
+			t.Error("ClearEnvInSettings() should return false when env field is already empty")
+		}
+
+		// Verify file unchanged
+		var loaded map[string]interface{}
+		readJSONFile(t, settingsPath, &loaded)
+		compareJSON(t, loaded, originalSettings)
+	})
+
 	t.Run("settings.json has invalid JSON", func(t *testing.T) {
 		tmpDir, cleanup := setupTestDir(t)
 		defer cleanup()


### PR DESCRIPTION
## Summary
- ClearEnvInSettings now checks if the env field is already empty before clearing
- Prevents "Cleared env field in settings.json to prevent configuration pollution" message from showing on every startup

## Problem
Previously, the function returned `true` whenever the `env` field existed in settings.json, even if it was already an empty object `{}`. This caused the message to be shown on every ccc startup after the first clear.

## Solution
Added a check to return `false` if the env field is a map with zero entries, indicating it's already been cleared.

## Test plan
- [x] Added test case for empty env field scenario
- [x] All existing tests pass