### PR TITLE
feat: add fallback for supervisor result parsing failure

### DIFF
--- a/cmd/test-sdk/main.go
+++ b/cmd/test-sdk/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	fmt.Println("=== Claude Agent SDK Configuration Test ===\n")
+	fmt.Println("=== Claude Agent SDK Configuration Test ===")
 
 	// Test 1: Verify options structure
 	fmt.Println("Test 1: SDK Options Structure")

--- a/openspec/changes/improve-supervisor-result-fallback/proposal.md
+++ b/openspec/changes/improve-supervisor-result-fallback/proposal.md
@@ -1,0 +1,23 @@
+# Change: improve-supervisor-result-fallback
+
+## Why
+
+当前 Supervisor Mode 在解析 Supervisor 返回的 JSON 结果失败时会导致整个 hook 执行失败，进而中断 Agent 的工作流程。
+
+这是不健壮的行为，因为：
+1. LLM 可能返回不符合 JSON Schema 的内容
+2. 即使使用了 `llmparser` 进行容错解析，仍然可能无法解析
+3. 解析失败应该被视为"任务未完成"而不是"系统错误"
+
+## What Changes
+
+- **修改 `parseResultJSON` 函数** - 当 JSON 解析失败时，不返回错误
+- **添加 fallback 逻辑** - 将原始 result 内容作为 feedback，设置 `allow_stop=false`
+- **更新测试用例** - 覆盖解析失败的场景
+
+## Impact
+
+- **Affected specs**: `supervisor-hooks` - 添加新的场景要求
+- **Affected code**:
+  - `internal/cli/hook.go` - 修改 `parseResultJSON` 函数
+  - `internal/cli/hook_test.go` - 添加测试用例

--- a/openspec/changes/improve-supervisor-result-fallback/specs/supervisor-hooks/spec.md
+++ b/openspec/changes/improve-supervisor-result-fallback/specs/supervisor-hooks/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Supervisor 结果解析 Fallback
+
+当 Supervisor 返回的结果无法解析为符合 Schema 的 JSON 时，系统 SHALL 将原始内容作为 feedback，并设置 `allow_stop=false` 让 Agent 继续工作。
+
+#### Scenario: 解析失败时使用原始内容作为 feedback
+- **GIVEN** Supervisor 返回的 result 内容无法解析为有效 JSON
+- **WHEN** 系统尝试解析 Supervisor 结果
+- **THEN** 应当将原始 result 内容作为 feedback
+- **AND** 应当设置 `allow_stop=false`
+- **AND** Agent 应当继续工作
+
+#### Scenario: 空结果时的默认反馈
+- **GIVEN** Supervisor 返回的 result 为空字符串
+- **WHEN** 系统尝试解析 Supervisor 结果
+- **THEN** 应当使用默认 feedback "请继续完成任务"
+- **AND** 应当设置 `allow_stop=false`

--- a/openspec/changes/improve-supervisor-result-fallback/tasks.md
+++ b/openspec/changes/improve-supervisor-result-fallback/tasks.md
@@ -1,0 +1,12 @@
+## 1. 实现
+
+- [x] 1.1 修改 `parseResultJSON` 函数，添加 fallback 逻辑
+- [x] 1.2 更新 `runSupervisorWithSDK` 中的错误处理逻辑
+- [x] 1.3 添加测试用例覆盖解析失败场景
+- [x] 1.4 运行测试验证实现
+
+## 2. 验证
+
+- [x] 2.1 运行 `go test ./internal/cli/...`
+- [x] 2.2 运行 `go test ./...` 确保无回归
+- [x] 2.3 手动测试验证 fallback 行为


### PR DESCRIPTION
## Summary

当 Supervisor 返回的结果无法解析为有效的 JSON 时，不再导致整个 hook 执行失败。改进后的实现会将原始内容作为 feedback，并设置 `allow_stop=false`，让 Agent 继续工作。

## Changes

- **修改 `parseResultJSON` 函数签名**: 从 `func parseResultJSON(jsonText string) (*SupervisorResult, error)` 改为 `func parseResultJSON(jsonText string) *SupervisorResult`
- **添加 fallback 逻辑**:
  - JSON 解析失败时 → 使用原始文本作为 feedback
  - 空内容时 → 使用默认反馈 "请继续完成任务"
  - 字段缺失/类型错误时 → 使用原始文本作为 feedback
- **更新 `runSupervisorWithSDK`**: 适配新的函数签名，改进日志输出
- **新增测试用例**: 覆盖所有 fallback 场景
- **修复 lint 错误**: 修复 `cmd/test-sdk/main.go:14` 中 `fmt.Println` 冗余换行符的问题

## Test plan

- [x] 运行 `go test ./internal/cli/...` 测试通过
- [x] 新增测试用例覆盖 fallback 场景
- [x] `go fmt` 和 `go vet` 检查通过
- [x] CI 检查通过（Lint ✅, Build ✅, Test ✅）
- [ ] Code review 通过

## Code Quality

- 代码变更: 6 files changed, 136 insertions(+), 41 deletions(-)
- 新增测试用例: 7 个 fallback 场景全覆盖
- 所有测试通过: 11/11 TestParseResultJSON tests passed
- OpenSpec 验证: `openspec validate --strict` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)