### PR TITLE
refactor(cli): remove duplicate CCC_SUPERVISOR env handling

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -238,16 +238,9 @@ func Run(cmd *Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to load supervisor config: %w", err)
 	}
-	supervisorEnabled := supervisorCfg.Enabled
-	switch os.Getenv("CCC_SUPERVISOR") {
-	case "1":
-		supervisorEnabled = true
-	case "0":
-		supervisorEnabled = false
-	}
 
 	// Run claude with the provider (handles both normal and supervisor mode)
-	return runClaude(cfg, providerName, cmd.ClaudeArgs, supervisorEnabled)
+	return runClaude(cfg, providerName, cmd.ClaudeArgs, supervisorCfg.Enabled)
 }
 
 // runValidate executes the validate command.


### PR DESCRIPTION
## Summary

- Remove duplicate `CCC_SUPERVISOR` environment variable handling in `cli.go`
- The env variable override is already implemented in `config.LoadSupervisorConfig()`
- This change eliminates code duplication and maintains a single source of truth

## Details

Previously, the `CCC_SUPERVISOR` environment variable was being checked in two places:
1. `cli.go:Run()` - checking and applying the override
2. `config.LoadSupervisorConfig()` - also checking and applying the override

The implementation in `config.LoadSupervisorConfig()` at line 62-65 already handles this correctly:
```go
if enabledEnv := os.Getenv("CCC_SUPERVISOR"); enabledEnv != "" {
    supervisorCfg.Enabled = enabledEnv == "1" || enabledEnv == "true"
}
```

This PR removes the redundant code from `cli.go`, relying entirely on the implementation in the config package.

## Test plan

- [x] All existing tests pass (`go test ./... -race`)
- [x] Integration tests in `internal/config/supervisor_integration_test.go` cover the env variable override logic
- [x] No functional changes - behavior remains identical