### PR TITLE
refactor(cli): check existing CCC_SUPERVISOR_ID before generating new UUID

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -35,10 +35,14 @@ func runClaude(cfg *config.Config, providerName string, claudeArgs []string, sup
 
 	// Generate settings for supervisor mode
 	if supervisorMode {
-		// Generate supervisor ID for this session
-		supervisorID = uuid.New().String()
-		// Set environment variable for hook to use
-		os.Setenv("CCC_SUPERVISOR_ID", supervisorID)
+		// Check if supervisor ID is already set in environment
+		// (e.g., from previous supervisor iteration)
+		supervisorID = os.Getenv("CCC_SUPERVISOR_ID")
+		if supervisorID == "" {
+			// Generate new supervisor ID for this session
+			supervisorID = uuid.New().String()
+			os.Setenv("CCC_SUPERVISOR_ID", supervisorID)
+		}
 
 		// Open log file and write initial messages directly to file
 		// (not to stderr, since hook hasn't started yet)


### PR DESCRIPTION
## Summary

- Check if `CCC_SUPERVISOR_ID` environment variable is already set before generating a new UUID
- This preserves the supervisor ID across iterations when the environment variable is already present (e.g., from previous supervisor iteration)

## Changes

Modified `internal/cli/exec.go` to:
1. First check if `CCC_SUPERVISOR_ID` is already in the environment
2. Only generate a new UUID if the environment variable is not set
3. Reuse existing supervisor ID when present

## Rationale

Previously, the code always generated a new UUID for supervisor mode, even when the environment variable was already set. This could cause issues in supervisor iteration scenarios where the same session ID should be preserved across multiple iterations.

## Test

- All existing tests pass
- Code follows gofmt and go vet standards