### PR TITLE
refactor(test): use strings.Contains instead of custom functions

### DIFF
--- a/internal/cli/cli_e2e_test.go
+++ b/internal/cli/cli_e2e_test.go
@@ -494,10 +494,10 @@ func TestE2E_ValidateCommand(t *testing.T) {
 
 			// Check that we got some validation output
 			outputStr := string(output)
-			if !contains(outputStr, "test1") {
+			if !strings.Contains(outputStr, "test1") {
 				t.Errorf("Expected provider name 'test1' in output, got: %s", outputStr)
 			}
-			if !contains(outputStr, "Base URL") {
+			if !strings.Contains(outputStr, "Base URL") {
 				t.Errorf("Expected 'Base URL' in output, got: %s", outputStr)
 			}
 		})
@@ -652,25 +652,11 @@ func TestE2E_SupervisorConfigLoading(t *testing.T) {
 
 			// The validate command should run successfully with the config
 			// If there's a config parsing error, it would fail before validation
-			if !contains(outputStr, "test1") {
+			if !strings.Contains(outputStr, "test1") {
 				t.Errorf("Expected provider name 'test1' in output, got: %s", outputStr)
 			}
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > len(substr) && findInString(s, substr)))
-}
-
-func findInString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 // TestE2E_Launching tests provider launching with various flags

--- a/internal/cli/supervisor_mode_test.go
+++ b/internal/cli/supervisor_mode_test.go
@@ -4,6 +4,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/guyskk/ccc/internal/config"
@@ -145,7 +146,7 @@ func TestSupervisorMode_Integration(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error when CCC_SUPERVISOR_ID is not set")
 		}
-		if !containsString(err.Error(), "CCC_SUPERVISOR_ID") {
+		if !strings.Contains(err.Error(), "CCC_SUPERVISOR_ID") {
 			t.Errorf("error message should mention CCC_SUPERVISOR_ID, got: %v", err)
 		}
 	})
@@ -218,18 +219,4 @@ func TestSupervisorMode_HookIntegration(t *testing.T) {
 			t.Errorf("expected Enabled=false, got true")
 		}
 	})
-}
-
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > len(substr) && findInStringLocal(s, substr)))
-}
-
-func findInStringLocal(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/config/supervisor_test.go
+++ b/internal/config/supervisor_test.go
@@ -3,7 +3,6 @@ package config
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 )
 
@@ -85,39 +84,6 @@ func TestSupervisorConfig_Timeout(t *testing.T) {
 	if timeout != 300000000000 { // 300 seconds in nanoseconds
 		t.Errorf("Timeout() = %v, want 300s", timeout)
 	}
-}
-
-func TestLoadSupervisorConfig_EnvOverride(t *testing.T) {
-	// Save original env values
-	origEnabled := os.Getenv("CCC_SUPERVISOR")
-	origMaxIter := os.Getenv("CCC_SUPERVISOR_MAX_ITERATIONS")
-	origTimeout := os.Getenv("CCC_SUPERVISOR_TIMEOUT")
-
-	// Restore after test
-	defer func() {
-		if origEnabled == "" {
-			os.Unsetenv("CCC_SUPERVISOR")
-		} else {
-			os.Setenv("CCC_SUPERVISOR", origEnabled)
-		}
-		if origMaxIter == "" {
-			os.Unsetenv("CCC_SUPERVISOR_MAX_ITERATIONS")
-		} else {
-			os.Setenv("CCC_SUPERVISOR_MAX_ITERATIONS", origMaxIter)
-		}
-		if origTimeout == "" {
-			os.Unsetenv("CCC_SUPERVISOR_TIMEOUT")
-		} else {
-			os.Setenv("CCC_SUPERVISOR_TIMEOUT", origTimeout)
-		}
-	}()
-
-	// This test requires a valid config file to exist
-	// For now, we skip if config doesn't exist
-	t.Skip("requires valid ccc.json config file")
-
-	// Test cases for env override would go here
-	// Set env vars, call LoadSupervisorConfig, verify overrides
 }
 
 func TestSupervisorConfig_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace custom `containsString`/`findInStringLocal` functions with Go's standard library `strings.Contains`
- Delete unimplemented `TestLoadSupervisorConfig_EnvOverride` test that has been skipped since initial implementation
- Remove unused `os` import from `supervisor_test.go`

## Changes

- `internal/cli/supervisor_mode_test.go`: Use `strings.Contains` and delete custom helper functions
- `internal/cli/cli_e2e_test.go`: Use `strings.Contains` and delete custom helper functions
- `internal/config/supervisor_test.go`: Remove skipped `TestLoadSupervisorConfig_EnvOverride` test and unused `os` import

## Motivation

This cleanup improves code consistency by using Go's standard library instead of reimplementing existing functionality. The custom `containsString` and `findInStringLocal` functions were duplicating behavior that `strings.Contains` already provides correctly.

The `TestLoadSupervisorConfig_EnvOverride` test was never implemented (always skipped) and is no longer relevant since supervisor configuration is now loaded from files rather than environment variables.

## Test plan

- [x] All existing tests pass
- [x] Lint checks pass (gofmt, go vet, shellcheck, markdownlint)
- [x] Build succeeds for all platforms (darwin/amd64, darwin/arm64, linux/amd64, linux/arm64)