### PR TITLE
test(integration): remove tests for non-existent Enabled field and deprecated env var

### DIFF
--- a/internal/cli/cli_e2e_test.go
+++ b/internal/cli/cli_e2e_test.go
@@ -509,11 +509,10 @@ func TestE2E_SupervisorConfigLoading(t *testing.T) {
 	tests := []struct {
 		name             string
 		configJSON       string
-		expectSupervisor bool   // whether supervisor section should exist in output
-		expectEnabled    bool   // expected enabled value
-		expectMaxIter    int    // expected max_iterations value
-		expectTimeout    int    // expected timeout_seconds value
-		envVar           string // optional CCC_SUPERVISOR env var
+		expectSupervisor bool // whether supervisor section should exist in output
+		expectEnabled    bool // expected enabled value
+		expectMaxIter    int  // expected max_iterations value
+		expectTimeout    int  // expected timeout_seconds value
 	}{
 		{
 			name: "supervisor_enabled_at_top_level",
@@ -582,39 +581,6 @@ func TestE2E_SupervisorConfigLoading(t *testing.T) {
 			expectMaxIter:    5,
 			expectTimeout:    600, // default
 		},
-		{
-			name: "env_var_enables_supervisor",
-			configJSON: `{
-				"settings": {"permissions": {"defaultMode": "acceptEdits"}},
-				"current_provider": "test1",
-				"providers": {
-					"test1": {"env": {"ANTHROPIC_AUTH_TOKEN": "test"}}
-				}
-			}`,
-			expectSupervisor: true,
-			expectEnabled:    true, // enabled by env var
-			expectMaxIter:    20,   // defaults
-			expectTimeout:    600,  // defaults
-			envVar:           "1",
-		},
-		{
-			name: "env_var_disables_supervisor",
-			configJSON: `{
-				"settings": {"permissions": {"defaultMode": "acceptEdits"}},
-				"supervisor": {
-					"enabled": true
-				},
-				"current_provider": "test1",
-				"providers": {
-					"test1": {"env": {"ANTHROPIC_AUTH_TOKEN": "test"}}
-				}
-			}`,
-			expectSupervisor: true,
-			expectEnabled:    false, // disabled by env var
-			expectMaxIter:    20,    // defaults
-			expectTimeout:    600,   // defaults
-			envVar:           "0",
-		},
 	}
 
 	for _, tt := range tests {
@@ -638,9 +604,6 @@ func TestE2E_SupervisorConfigLoading(t *testing.T) {
 			// Run ccc validate to trigger config loading
 			cmd := exec.CommandContext(ctx, cccBinaryPath, "validate")
 			cmd.Env = append(os.Environ(), fmt.Sprintf("CCC_CONFIG_DIR=%s", testConfigDir))
-			if tt.envVar != "" {
-				cmd.Env = append(cmd.Env, fmt.Sprintf("CCC_SUPERVISOR=%s", tt.envVar))
-			}
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Logf("Command completed with error (API test may fail): %v", err)

--- a/internal/config/supervisor_integration_test.go
+++ b/internal/config/supervisor_integration_test.go
@@ -11,19 +11,9 @@ import (
 
 // TestSupervisorConfig_Integration tests real config file loading scenarios
 func TestSupervisorConfig_Integration(t *testing.T) {
-	// Save and clear CCC_SUPERVISOR env var for clean testing
-	origEnv := os.Getenv("CCC_SUPERVISOR")
-	os.Unsetenv("CCC_SUPERVISOR")
-	defer func() {
-		if origEnv != "" {
-			os.Setenv("CCC_SUPERVISOR", origEnv)
-		}
-	}()
-
 	testCases := []struct {
 		name        string
 		configJSON  string
-		wantEnabled bool
 		wantMaxIter int
 		wantTimeout int
 	}{
@@ -32,14 +22,12 @@ func TestSupervisorConfig_Integration(t *testing.T) {
 			configJSON: `{
 				"settings": {},
 				"supervisor": {
-					"enabled": true,
 					"max_iterations": 20,
 					"timeout_seconds": 600
 				},
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: true,
 			wantMaxIter: 20,
 			wantTimeout: 600,
 		},
@@ -50,22 +38,20 @@ func TestSupervisorConfig_Integration(t *testing.T) {
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: false,
 			wantMaxIter: 20,  // defaults
 			wantTimeout: 600, // defaults
 		},
 		{
-			name: "partial_supervisor_config_only_enabled",
+			name: "partial_supervisor_config_only_max_iterations",
 			configJSON: `{
 				"settings": {},
 				"supervisor": {
-					"enabled": true
+					"max_iterations": 15
 				},
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: true,
-			wantMaxIter: 20,  // defaults
+			wantMaxIter: 15,
 			wantTimeout: 600, // defaults
 		},
 		{
@@ -78,7 +64,6 @@ func TestSupervisorConfig_Integration(t *testing.T) {
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: false,
 			wantMaxIter: 10,  // custom value
 			wantTimeout: 600, // defaults
 		},
@@ -109,9 +94,6 @@ func TestSupervisorConfig_Integration(t *testing.T) {
 			}
 
 			// Check values
-			if supervisorCfg.Enabled != tc.wantEnabled {
-				t.Errorf("Enabled = %v, want %v", supervisorCfg.Enabled, tc.wantEnabled)
-			}
 			if supervisorCfg.MaxIterations != tc.wantMaxIter {
 				t.Errorf("MaxIterations = %v, want %v", supervisorCfg.MaxIterations, tc.wantMaxIter)
 			}
@@ -124,15 +106,6 @@ func TestSupervisorConfig_Integration(t *testing.T) {
 
 // TestSupervisorConfig_NilHandling tests nil supervisor config handling
 func TestSupervisorConfig_NilHandling(t *testing.T) {
-	// Save and clear CCC_SUPERVISOR env var for clean testing
-	origEnv := os.Getenv("CCC_SUPERVISOR")
-	os.Unsetenv("CCC_SUPERVISOR")
-	defer func() {
-		if origEnv != "" {
-			os.Setenv("CCC_SUPERVISOR", origEnv)
-		}
-	}()
-
 	// Save original GetDirFunc
 	origGetDirFunc := GetDirFunc
 
@@ -160,9 +133,6 @@ func TestSupervisorConfig_NilHandling(t *testing.T) {
 	}
 
 	// Verify defaults are used
-	if supervisorCfg.Enabled != false {
-		t.Errorf("Enabled = %v, want false (default)", supervisorCfg.Enabled)
-	}
 	if supervisorCfg.MaxIterations != 20 {
 		t.Errorf("MaxIterations = %v, want 20 (default)", supervisorCfg.MaxIterations)
 	}
@@ -173,15 +143,6 @@ func TestSupervisorConfig_NilHandling(t *testing.T) {
 
 // TestSupervisorConfig_EdgeCases tests edge cases and boundary conditions
 func TestSupervisorConfig_EdgeCases(t *testing.T) {
-	// Save and clear CCC_SUPERVISOR env var for clean testing
-	origEnv := os.Getenv("CCC_SUPERVISOR")
-	os.Unsetenv("CCC_SUPERVISOR")
-	defer func() {
-		if origEnv != "" {
-			os.Setenv("CCC_SUPERVISOR", origEnv)
-		}
-	}()
-
 	// Save original GetDirFunc
 	origGetDirFunc := GetDirFunc
 	defer func() { GetDirFunc = origGetDirFunc }()
@@ -189,7 +150,6 @@ func TestSupervisorConfig_EdgeCases(t *testing.T) {
 	testCases := []struct {
 		name        string
 		configJSON  string
-		wantEnabled bool
 		wantMaxIter int
 		wantTimeout int
 	}{
@@ -201,25 +161,22 @@ func TestSupervisorConfig_EdgeCases(t *testing.T) {
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: false, // default
-			wantMaxIter: 20,    // default (empty object means no values set)
-			wantTimeout: 600,   // default
+			wantMaxIter: 20,  // default (empty object means no values set)
+			wantTimeout: 600, // default
 		},
 		{
 			name: "zero_values_in_config_uses_defaults",
 			configJSON: `{
 				"settings": {},
 				"supervisor": {
-					"enabled": false,
 					"max_iterations": 0,
 					"timeout_seconds": 0
 				},
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: false, // false is default
-			wantMaxIter: 20,    // 0 is invalid, uses default
-			wantTimeout: 600,   // 0 is invalid, uses default
+			wantMaxIter: 20,  // 0 is invalid, uses default
+			wantTimeout: 600, // 0 is invalid, uses default
 		},
 		{
 			name: "only_timeout_customized",
@@ -231,23 +188,20 @@ func TestSupervisorConfig_EdgeCases(t *testing.T) {
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: false, // default
-			wantMaxIter: 20,    // default
-			wantTimeout: 120,   // custom value
+			wantMaxIter: 20,  // default
+			wantTimeout: 120, // custom value
 		},
 		{
 			name: "all_fields_customized",
 			configJSON: `{
 				"settings": {},
 				"supervisor": {
-					"enabled": true,
 					"max_iterations": 50,
 					"timeout_seconds": 900
 				},
 				"current_provider": "kimi",
 				"providers": {}
 			}`,
-			wantEnabled: true,
 			wantMaxIter: 50,
 			wantTimeout: 900,
 		},
@@ -274,121 +228,11 @@ func TestSupervisorConfig_EdgeCases(t *testing.T) {
 			}
 
 			// Check values
-			if supervisorCfg.Enabled != tc.wantEnabled {
-				t.Errorf("Enabled = %v, want %v", supervisorCfg.Enabled, tc.wantEnabled)
-			}
 			if supervisorCfg.MaxIterations != tc.wantMaxIter {
 				t.Errorf("MaxIterations = %v, want %v", supervisorCfg.MaxIterations, tc.wantMaxIter)
 			}
 			if supervisorCfg.TimeoutSeconds != tc.wantTimeout {
 				t.Errorf("TimeoutSeconds = %v, want %v", supervisorCfg.TimeoutSeconds, tc.wantTimeout)
-			}
-		})
-	}
-}
-
-// TestSupervisorConfig_EnvironmentVariableOverride tests env var override
-func TestSupervisorConfig_EnvironmentVariableOverride(t *testing.T) {
-	// Save original GetDirFunc
-	origGetDirFunc := GetDirFunc
-	defer func() { GetDirFunc = origGetDirFunc }()
-
-	testCases := []struct {
-		name        string
-		configJSON  string
-		envVar      string
-		wantEnabled bool
-		description string
-	}{
-		{
-			name: "env_var_1_enables_supervisor",
-			configJSON: `{
-				"settings": {},
-				"current_provider": "kimi",
-				"providers": {}
-			}`,
-			envVar:      "1",
-			wantEnabled: true,
-			description: "CCC_SUPERVISOR=1 should enable supervisor",
-		},
-		{
-			name: "env_var_true_enables_supervisor",
-			configJSON: `{
-				"settings": {},
-				"current_provider": "kimi",
-				"providers": {}
-			}`,
-			envVar:      "true",
-			wantEnabled: true,
-			description: "CCC_SUPERVISOR=true should enable supervisor",
-		},
-		{
-			name: "env_var_0_disables_supervisor",
-			configJSON: `{
-				"settings": {},
-				"supervisor": {"enabled": true},
-				"current_provider": "kimi",
-				"providers": {}
-			}`,
-			envVar:      "0",
-			wantEnabled: false,
-			description: "CCC_SUPERVISOR=0 should disable supervisor even if config has enabled=true",
-		},
-		{
-			name: "env_var_false_disables_supervisor",
-			configJSON: `{
-				"settings": {},
-				"supervisor": {"enabled": true},
-				"current_provider": "kimi",
-				"providers": {}
-			}`,
-			envVar:      "false",
-			wantEnabled: false,
-			description: "CCC_SUPERVISOR=false should disable supervisor even if config has enabled=true",
-		},
-		{
-			name: "env_var_random_does_not_enable",
-			configJSON: `{
-				"settings": {},
-				"current_provider": "kimi",
-				"providers": {}
-			}`,
-			envVar:      "random",
-			wantEnabled: false,
-			description: "CCC_SUPERVISOR=random should not enable supervisor",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Clear env var first
-			os.Unsetenv("CCC_SUPERVISOR")
-
-			// Create temporary config dir
-			tmpDir := t.TempDir()
-			configPath := filepath.Join(tmpDir, "ccc.json")
-
-			// Write test config to temp dir
-			if err := os.WriteFile(configPath, []byte(tc.configJSON), 0644); err != nil {
-				t.Fatalf("failed to write test config: %v", err)
-			}
-
-			// Set env var
-			os.Setenv("CCC_SUPERVISOR", tc.envVar)
-			defer os.Unsetenv("CCC_SUPERVISOR")
-
-			// Override GetDirFunc to use temp dir
-			GetDirFunc = func() string { return tmpDir }
-
-			// Load supervisor config
-			supervisorCfg, err := LoadSupervisorConfig()
-			if err != nil {
-				t.Fatalf("LoadSupervisorConfig() error = %v", err)
-			}
-
-			// Check enabled value
-			if supervisorCfg.Enabled != tc.wantEnabled {
-				t.Errorf("%s: Enabled = %v, want %v", tc.description, supervisorCfg.Enabled, tc.wantEnabled)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Remove `env_var_enables_supervisor` and `env_var_disables_supervisor` test cases from `TestE2E_SupervisorConfigLoading` (the `CCC_SUPERVISOR` env var is deprecated)
- Rewrite `supervisor_integration_test.go` to test only actual fields (`MaxIterations` and `TimeoutSeconds`)
- Remove `TestSupervisorConfig_EnvironmentVariableOverride` entirely
- Remove all references to `supervisorCfg.Enabled` (which doesn't exist on `SupervisorConfig` struct)

## Changes

- `internal/cli/cli_e2e_test.go`: Remove envVar field from test struct and related test cases
- `internal/config/supervisor_integration_test.go`: Complete rewrite to test only actual struct fields

## Motivation

The `SupervisorConfig` struct only has two fields:
- `MaxIterations int`
- `TimeoutSeconds int`

It does NOT have an `Enabled` field. The supervisor enabled state is now controlled by state files (via `supervisor-mode` command), not by config files or environment variables.

The tests were incorrectly testing for a non-existent `Enabled` field and deprecated `CCC_SUPERVISOR` environment variable behavior.

## Test plan

- [x] All existing tests pass
- [x] Lint checks pass (gofmt, go vet, shellcheck, markdownlint)
- [x] Build succeeds for all platforms (darwin/amd64, darwin/arm64, linux/amd64, linux/arm64)