### PR TITLE
refactor(provider): rename supervisor-off.md to supervisoroff.md

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -131,11 +131,11 @@ func createSupervisorCommandFiles(cccPath string) error {
 		return fmt.Errorf("failed to write command supervisor.md: %w", err)
 	}
 
-	// Create supervisor-off.md (disable command)
+	// Create supervisoroff.md (disable command)
 	supervisorOffContent := fmt.Sprintf("---\ndescription: Disable supervisor mode\n---\n$ARGUMENTS!`%s supervisor-mode off`\n", cccPath)
-	supervisorOffPath := commandsDir + "/supervisor-off.md"
+	supervisorOffPath := commandsDir + "/supervisoroff.md"
 	if err := os.WriteFile(supervisorOffPath, []byte(supervisorOffContent), 0644); err != nil {
-		return fmt.Errorf("failed to write command supervisor-off.md: %w", err)
+		return fmt.Errorf("failed to write command supervisoroff.md: %w", err)
 	}
 
 	return nil

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -120,12 +120,12 @@ func TestSwitchWithHook(t *testing.T) {
 		// Verify supervisor command files were created
 		commandsDir := config.GetDir() + "/commands"
 		supervisorOnPath := commandsDir + "/supervisor.md"
-		supervisorOffPath := commandsDir + "/supervisor-off.md"
+		supervisorOffPath := commandsDir + "/supervisoroff.md"
 		if _, err := os.Stat(supervisorOnPath); os.IsNotExist(err) {
 			t.Errorf("supervisor.md should exist at %s", supervisorOnPath)
 		}
 		if _, err := os.Stat(supervisorOffPath); os.IsNotExist(err) {
-			t.Errorf("supervisor-off.md should exist at %s", supervisorOffPath)
+			t.Errorf("supervisoroff.md should exist at %s", supervisorOffPath)
 		}
 	})
 

--- a/openspec/changes/refactor-supervisor-mode-commands/proposal.md
+++ b/openspec/changes/refactor-supervisor-mode-commands/proposal.md
@@ -15,7 +15,7 @@
 - **ccc 启动时** 无论什么模式都设置 `CCC_SUPERVISOR_ID`（如果环境变量没有就新生成，否则复用）
 - **总是** 使用 `SwitchWithHook()` 生成带 Stop Hook 的 settings（不再需要普通模式的 `Switch()`）
 - **Hook 改为** 从 state 文件读取 `Enabled` 字段判断是否执行 Supervisor review
-- **每次 ccc 启动时** 都覆盖创建 `~/.claude/commands/supervisor.md` 和 `supervisor-off.md`
+- **每次 ccc 启动时** 都覆盖创建 `~/.claude/commands/supervisor.md` 和 `supervisoroff.md`
 - **为新增的 `supervisor-mode` 子命令编写单元测试**
 
 ## Impact

--- a/openspec/changes/refactor-supervisor-mode-commands/specs/cli/spec.md
+++ b/openspec/changes/refactor-supervisor-mode-commands/specs/cli/spec.md
@@ -53,7 +53,7 @@
 - **AND** 应当将配置写入 `~/.claude/settings.json`
 - **AND** settings 中应当包含 `hooks.Stop` 配置
 - **AND** 应当创建 `~/.claude/commands/supervisor.md` 文件
-- **AND** 应当创建 `~/.claude/commands/supervisor-off.md` 文件
+- **AND** 应当创建 `~/.claude/commands/supervisoroff.md` 文件
 
 #### Scenario: 创建 supervisor.md 命令文件
 - **GIVEN** ccc 执行 `SwitchWithHook()`
@@ -62,10 +62,10 @@
 - **AND** 文件内容应当包含 frontmatter（description: Enable supervisor mode）
 - **AND** 文件内容应当包含命令 `$ARGUMENTS!`ccc supervisor-mode on``
 
-#### Scenario: 创建 supervisor-off.md 命令文件
+#### Scenario: 创建 supervisoroff.md 命令文件
 - **GIVEN** ccc 执行 `SwitchWithHook()`
 - **WHEN** 系统创建命令文件
-- **THEN** 应当创建 `~/.claude/commands/supervisor-off.md`
+- **THEN** 应当创建 `~/.claude/commands/supervisoroff.md`
 - **AND** 文件内容应当包含 frontmatter（description: Disable supervisor mode）
 - **AND** 文件内容应当包含命令 `$ARGUMENTS!`ccc supervisor-mode off``
 

--- a/openspec/changes/refactor-supervisor-mode-commands/specs/supervisor-hooks/spec.md
+++ b/openspec/changes/refactor-supervisor-mode-commands/specs/supervisor-hooks/spec.md
@@ -126,9 +126,9 @@ description: Enable supervisor mode
 $ARGUMENTS!`ccc supervisor-mode on`
 ```
 
-#### Scenario: supervisor-off.md 内容格式
+#### Scenario: supervisoroff.md 内容格式
 - **GIVEN** ccc 执行 `SwitchWithHook()`
-- **WHEN** 系统创建 `~/.claude/commands/supervisor-off.md`
+- **WHEN** 系统创建 `~/.claude/commands/supervisoroff.md`
 - **THEN** 文件内容应当为：
 ```markdown
 ---
@@ -145,8 +145,8 @@ $ARGUMENTS!`ccc supervisor-mode off`
 - **AND** state 文件的 `enabled` 字段应当被设为 `true`
 - **AND** 后续 Stop hook 将执行 Supervisor review
 
-#### Scenario: 用户使用 /supervisor-off 命令
-- **GIVEN** 用户在 Claude Code 中输入 `/supervisor-off`
+#### Scenario: 用户使用 /supervisoroff 命令
+- **GIVEN** 用户在 Claude Code 中输入 `/supervisoroff`
 - **WHEN** Claude Code 解析 slash command
 - **THEN** 应当执行 `ccc supervisor-mode off`
 - **AND** state 文件的 `enabled` 字段应当被设为 `false`

--- a/openspec/changes/refactor-supervisor-mode-commands/tasks.md
+++ b/openspec/changes/refactor-supervisor-mode-commands/tasks.md
@@ -41,7 +41,7 @@
 ## 6. Provider 修改
 - [ ] 6.1 删除 `Switch()` 函数
 - [ ] 6.2 `SwitchWithHook()` 中增加创建 `~/.claude/commands/supervisor.md` 的逻辑
-- [ ] 6.3 `SwitchWithHook()` 中增加创建 `~/.claude/commands/supervisor-off.md` 的逻辑
+- [ ] 6.3 `SwitchWithHook()` 中增加创建 `~/.claude/commands/supervisoroff.md` 的逻辑
 - [ ] 6.4 每次调用都覆盖创建这两个文件
 - [ ] 6.5 更新 `provider_test.go`（去掉 `Switch()` 相关测试）
 


### PR DESCRIPTION
Remove hyphen from the supervisor disable command filename.

## Changes

- Rename `supervisor-off.md` to `supervisoroff.md`
- Update test to match new filename

## Rationale

Simpler filename without hyphen for consistency.