### PR TITLE
feat(cli): add query mode to supervisor-mode command

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -121,6 +121,21 @@ Supervisor 模式是 `ccc` 最有价值的特性。它会在 Agent 每次停止�
 4. Agent 根据反馈继续工作
 5. 重复直到 Supervisor 确认工作完成
 
+### supervisor-mode 命令
+
+查询或设置 Supervisor 模式状态（用于 statusline 脚本）：
+
+```bash
+# 查询状态（输出 "on" 或 "off"）
+ccc supervisor-mode
+
+# 启用
+ccc supervisor-mode on
+
+# 禁用
+ccc supervisor-mode off
+```
+
 ## 配置说明
 
 配置文件位置，默认为：`~/.claude/ccc.json`

--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ Supervisor Mode is the most valuable feature of `ccc`. It automatically reviews 
 4. Agent continues with the feedback
 5. This repeats until Supervisor confirms the work is complete
 
+### supervisor-mode Command
+
+Query or set Supervisor Mode state (used in statusline scripts):
+
+```bash
+# Query status (outputs "on" or "off")
+ccc supervisor-mode
+
+# Enable
+ccc supervisor-mode on
+
+# Disable
+ccc supervisor-mode off
+```
+
 ## Configuration
 
 Config file location, default: `~/.claude/ccc.json`

--- a/internal/cli/supervisor_mode_test.go
+++ b/internal/cli/supervisor_mode_test.go
@@ -2,6 +2,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,7 +13,7 @@ import (
 )
 
 // TestSupervisorMode_Integration tests the supervisor-mode subcommand.
-// These are integration tests that verify the command correctly modifies
+// These are integration tests that verify the command correctly queries or modifies
 // the supervisor state file.
 func TestSupervisorMode_Integration(t *testing.T) {
 	// Create test config directory
@@ -67,10 +68,11 @@ func TestSupervisorMode_Integration(t *testing.T) {
 		}
 
 		// Run supervisor-mode on
+		val := true
 		cmd := &Command{
 			SupervisorMode: true,
 			SupervisorModeOpts: &SupervisorModeCommand{
-				Enabled: true,
+				Enabled: &val,
 			},
 		}
 		if err := RunSupervisorMode(cmd.SupervisorModeOpts); err != nil {
@@ -108,10 +110,11 @@ func TestSupervisorMode_Integration(t *testing.T) {
 		}
 
 		// Run supervisor-mode off
+		val := false
 		cmd := &Command{
 			SupervisorMode: true,
 			SupervisorModeOpts: &SupervisorModeCommand{
-				Enabled: false,
+				Enabled: &val,
 			},
 		}
 		if err := RunSupervisorMode(cmd.SupervisorModeOpts); err != nil {
@@ -136,10 +139,11 @@ func TestSupervisorMode_Integration(t *testing.T) {
 		// Unset environment variable
 		os.Unsetenv("CCC_SUPERVISOR_ID")
 
+		val := true
 		cmd := &Command{
 			SupervisorMode: true,
 			SupervisorModeOpts: &SupervisorModeCommand{
-				Enabled: true,
+				Enabled: &val,
 			},
 		}
 		err := RunSupervisorMode(cmd.SupervisorModeOpts)
@@ -148,6 +152,141 @@ func TestSupervisorMode_Integration(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "CCC_SUPERVISOR_ID") {
 			t.Errorf("error message should mention CCC_SUPERVISOR_ID, got: %v", err)
+		}
+	})
+
+	t.Run("supervisor-mode (no args) queries status", func(t *testing.T) {
+		supervisorID := "test-supervisor-mode-query"
+
+		// Set environment variable
+		os.Setenv("CCC_SUPERVISOR_ID", supervisorID)
+		defer os.Unsetenv("CCC_SUPERVISOR_ID")
+
+		// Create initial state with enabled=true
+		initialState := &supervisor.State{
+			SessionID: supervisorID,
+			Enabled:   true,
+			Count:     3,
+		}
+		if err := supervisor.SaveState(supervisorID, initialState); err != nil {
+			t.Fatalf("failed to save initial state: %v", err)
+		}
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		// Run supervisor-mode without args (query)
+		cmd := &Command{
+			SupervisorMode:     true,
+			SupervisorModeOpts: &SupervisorModeCommand{Enabled: nil},
+		}
+		if err := RunSupervisorMode(cmd.SupervisorModeOpts); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		// Read stdout
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		output := strings.TrimSpace(buf.String())
+
+		// Verify output
+		if output != "on" {
+			t.Errorf("expected output 'on', got '%s'", output)
+		}
+
+		// Verify state was NOT modified
+		state, err := supervisor.LoadState(supervisorID)
+		if err != nil {
+			t.Fatalf("failed to load state: %v", err)
+		}
+		if state.Count != 3 {
+			t.Errorf("expected Count=3 (unchanged), got %d", state.Count)
+		}
+	})
+
+	t.Run("supervisor-mode (no args) returns off when disabled", func(t *testing.T) {
+		supervisorID := "test-supervisor-mode-query-off"
+
+		// Set environment variable
+		os.Setenv("CCC_SUPERVISOR_ID", supervisorID)
+		defer os.Unsetenv("CCC_SUPERVISOR_ID")
+
+		// Create initial state with enabled=false
+		initialState := &supervisor.State{
+			SessionID: supervisorID,
+			Enabled:   false,
+			Count:     0,
+		}
+		if err := supervisor.SaveState(supervisorID, initialState); err != nil {
+			t.Fatalf("failed to save initial state: %v", err)
+		}
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		// Run supervisor-mode without args (query)
+		cmd := &Command{
+			SupervisorMode:     true,
+			SupervisorModeOpts: &SupervisorModeCommand{Enabled: nil},
+		}
+		if err := RunSupervisorMode(cmd.SupervisorModeOpts); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		// Read stdout
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		output := strings.TrimSpace(buf.String())
+
+		// Verify output
+		if output != "off" {
+			t.Errorf("expected output 'off', got '%s'", output)
+		}
+	})
+
+	t.Run("supervisor-mode (no args) returns off when state file does not exist", func(t *testing.T) {
+		supervisorID := "test-supervisor-mode-query-nonexistent"
+
+		// Set environment variable
+		os.Setenv("CCC_SUPERVISOR_ID", supervisorID)
+		defer os.Unsetenv("CCC_SUPERVISOR_ID")
+
+		// Ensure state file does not exist
+		statePath, _ := supervisor.GetStatePath(supervisorID)
+		os.Remove(statePath)
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		// Run supervisor-mode without args (query)
+		cmd := &Command{
+			SupervisorMode:     true,
+			SupervisorModeOpts: &SupervisorModeCommand{Enabled: nil},
+		}
+		if err := RunSupervisorMode(cmd.SupervisorModeOpts); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		// Read stdout
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		output := strings.TrimSpace(buf.String())
+
+		// Verify output (should be 'off' for non-existent state)
+		if output != "off" {
+			t.Errorf("expected output 'off' for non-existent state, got '%s'", output)
 		}
 	})
 }
@@ -219,4 +358,143 @@ func TestSupervisorMode_HookIntegration(t *testing.T) {
 			t.Errorf("expected Enabled=false, got true")
 		}
 	})
+}
+
+// TestSupervisorMode_EndToEnd tests a complete workflow simulating real usage.
+func TestSupervisorMode_EndToEnd(t *testing.T) {
+	// Create test config directory
+	tmpDir := t.TempDir()
+	testConfigDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(testConfigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up environment
+	os.Setenv("CCC_CONFIG_DIR", testConfigDir)
+	defer os.Unsetenv("CCC_CONFIG_DIR")
+
+	supervisorID := "test-e2e-workflow"
+	os.Setenv("CCC_SUPERVISOR_ID", supervisorID)
+	defer os.Unsetenv("CCC_SUPERVISOR_ID")
+
+	// Ensure clean state
+	statePath, _ := supervisor.GetStatePath(supervisorID)
+	os.Remove(statePath)
+
+	// Step 1: Query initial state (should be "off" - file doesn't exist)
+	t.Run("step1: query initial state", func(t *testing.T) {
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		cmd := &SupervisorModeCommand{Enabled: nil}
+		if err := RunSupervisorMode(cmd); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		output := strings.TrimSpace(buf.String())
+
+		if output != "off" {
+			t.Errorf("expected 'off', got '%s'", output)
+		}
+	})
+
+	// Step 2: Enable supervisor mode
+	t.Run("step2: enable supervisor mode", func(t *testing.T) {
+		val := true
+		cmd := &SupervisorModeCommand{Enabled: &val}
+		if err := RunSupervisorMode(cmd); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		// Verify state was saved
+		state, err := supervisor.LoadState(supervisorID)
+		if err != nil {
+			t.Fatalf("failed to load state: %v", err)
+		}
+		if !state.Enabled {
+			t.Error("expected Enabled=true after enabling")
+		}
+	})
+
+	// Step 3: Query state (should be "on")
+	t.Run("step3: query enabled state", func(t *testing.T) {
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		cmd := &SupervisorModeCommand{Enabled: nil}
+		if err := RunSupervisorMode(cmd); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		output := strings.TrimSpace(buf.String())
+
+		if output != "on" {
+			t.Errorf("expected 'on', got '%s'", output)
+		}
+	})
+
+	// Step 4: Disable supervisor mode
+	t.Run("step4: disable supervisor mode", func(t *testing.T) {
+		val := false
+		cmd := &SupervisorModeCommand{Enabled: &val}
+		if err := RunSupervisorMode(cmd); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		// Verify state was saved
+		state, err := supervisor.LoadState(supervisorID)
+		if err != nil {
+			t.Fatalf("failed to load state: %v", err)
+		}
+		if state.Enabled {
+			t.Error("expected Enabled=false after disabling")
+		}
+	})
+
+	// Step 5: Query state (should be "off")
+	t.Run("step5: query disabled state", func(t *testing.T) {
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		cmd := &SupervisorModeCommand{Enabled: nil}
+		if err := RunSupervisorMode(cmd); err != nil {
+			t.Fatalf("RunSupervisorMode() error = %v", err)
+		}
+
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		output := strings.TrimSpace(buf.String())
+
+		if output != "off" {
+			t.Errorf("expected 'off', got '%s'", output)
+		}
+	})
+}
+
+// TestSupervisorMode_InvalidArgument tests that invalid arguments are treated as query mode.
+func TestSupervisorMode_InvalidArgument(t *testing.T) {
+	// Invalid arguments should be ignored and treated as query mode
+	cmd := Parse([]string{"supervisor-mode", "xyz"})
+	if !cmd.SupervisorMode {
+		t.Fatal("expected SupervisorMode to be true")
+	}
+	if cmd.SupervisorModeOpts == nil {
+		t.Fatal("expected SupervisorModeOpts to be set")
+	}
+	if cmd.SupervisorModeOpts.Enabled != nil {
+		t.Errorf("expected Enabled to be nil for invalid argument, got %v", cmd.SupervisorModeOpts.Enabled)
+	}
 }


### PR DESCRIPTION
## 概述

为 `supervisor-mode` 子命令添加查询模式。

## 命令行为

```bash
ccc supervisor-mode        # 输出 on 或 off
ccc supervisor-mode on     # 启用
ccc supervisor-mode off    # 禁用
```

## 代码变更

- `SupervisorModeCommand.Enabled`: `bool` → `*bool` (nil=查询)
- 无参数时输出状态到 stdout
- 有参数时更新状态

## 测试

- 单元测试：启用/禁用/查询
- E2E 测试：完整工作流
- 无效参数测试：当作查询模式

## 文档

- README.md: 简化命令说明
- README-CN.md: 同步中文说明