### PR TITLE
fix: preserve user env in settings.json

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -77,9 +77,6 @@ func SwitchWithHook(cfg *config.Config, providerName string) (*SwitchResult, err
 	// This also sets disableAllHooks and allowManagedHooksOnly to false
 	settingsWithHook = config.EnsureStopHook(settingsWithHook, hookCommand)
 
-	// Remove env from settings before saving (provider env is passed via command line)
-	delete(settingsWithHook, "env")
-
 	// Save merged settings to settings.json
 	settingsPath := config.GetSettingsPath()
 	settingsData, err := json.MarshalIndent(settingsWithHook, "", "  ")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -96,9 +96,34 @@ func TestSwitchWithHook(t *testing.T) {
 			t.Errorf("API_TIMEOUT = %v, want 30000", envMap["API_TIMEOUT"])
 		}
 
-		// Verify settings does not contain env
-		if _, exists := result.Settings["env"]; exists {
-			t.Error("Settings should not contain 'env' field")
+		// Verify settings does not contain provider env but contains user env
+		settingsEnv, exists := result.Settings["env"]
+		if !exists {
+			t.Fatal("Settings should contain 'env' field")
+		}
+		
+		settingsEnvMap, ok := settingsEnv.(map[string]interface{})
+		if !ok {
+			t.Fatal("env should be a map")
+		}
+		
+		// Should not contain provider env variables
+		if _, exists := settingsEnvMap["ANTHROPIC_BASE_URL"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_BASE_URL")
+		}
+		if _, exists := settingsEnvMap["ANTHROPIC_AUTH_TOKEN"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_AUTH_TOKEN")
+		}
+		if _, exists := settingsEnvMap["ANTHROPIC_MODEL"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_MODEL")
+		}
+		
+		// Should contain user env variables
+		if settingsEnvMap["API_TIMEOUT"] != "30000" {
+			t.Error("Settings should contain user API_TIMEOUT")
+		}
+		if settingsEnvMap["DISABLE_TELEMETRY"] != "1" {
+			t.Error("Settings should contain user DISABLE_TELEMETRY")
 		}
 
 		// Verify hooks are present

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -111,6 +111,9 @@ func TestSwitchWithHook(t *testing.T) {
 		if _, exists := settingsEnvMap["ANTHROPIC_BASE_URL"]; exists {
 			t.Error("Settings should not contain provider ANTHROPIC_BASE_URL")
 		}
+		if _, exists := settingsEnvMap["ANTHROPIC_API_KEY"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_API_KEY")
+		}
 		if _, exists := settingsEnvMap["ANTHROPIC_AUTH_TOKEN"]; exists {
 			t.Error("Settings should not contain provider ANTHROPIC_AUTH_TOKEN")
 		}


### PR DESCRIPTION
## Summary
- preserve user-defined env entries in ~/.claude/settings.json when ccc runs
- continue removing provider-specific and Claude/Anthropic-prefixed env values from persisted settings
- update provider tests to cover the preserved user env behavior

## Testing
- go test ./internal/provider ./internal/config

## Related
- fixes #74