### PR TITLE
Preserve user env settings during provider switch

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -109,7 +109,7 @@ ccc validate --all
 #### 管理的内容
 
 - 🤖 Supervisor Stop hook - 自动添加/确保
-- 🧹 环境变量冲突 - `ANTHROPIC_*`、`CLAUDE_*` 和提供商 env 键从 `settings.json` 中移除以避免歧义
+- 🧹 环境变量冲突 - 与当前提供商 env 同名的 key 会从 `settings.json` 中移除以避免歧义
 - ⚙️ Hook 执行标志 - `disableAllHooks` 和 `allowManagedHooksOnly` 设置为 `false` 以确保 hooks 能正常工作
 
 #### 工作原理

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Config file location, default: `~/.claude/ccc.json`
 #### What Gets Managed
 
 - 🤖 Supervisor Stop hook - automatically added/ensured
-- 🧹 Environment variable conflicts - `ANTHROPIC_*`, `CLAUDE_*`, and provider env keys are removed from `settings.json` to avoid ambiguity
+- 🧹 Environment variable conflicts - keys also defined by the current provider env are removed from `settings.json` to avoid ambiguity
 - ⚙️ Hook execution flags - `disableAllHooks` and `allowManagedHooksOnly` set to `false` to ensure hooks work
 
 #### How It Works

--- a/docs/settings-merge-strategy.md
+++ b/docs/settings-merge-strategy.md
@@ -76,8 +76,7 @@ ccc 不应该：
 **处理方式**：清空特定键，避免配置冲突。
 
 需要清空的键：
-1. 特定前缀：`ANTHROPIC_*`、`CLAUDE_*`
-2. 与 provider env 相同的 key
+1. 与 provider env 相同的 key
 
 **原因**：
 - provider 的环境变量通过命令行传递给 claude 子进程
@@ -90,23 +89,23 @@ ccc 不应该：
 // settings.json 初始内容
 {
   "env": {
-    "ANTHROPIC_MODEL": "claude-3.7-sonnet",
-    "MY_CUSTOM_VAR": "value",
-    "ANTHROPIC_BASE_URL": "old-url"
+    "ANTHROPIC_API_KEY": "user-key",
+    "ANTHROPIC_BASE_URL": "old-url",
+    "MY_CUSTOM_VAR": "value"
   }
 }
 
 // provider env
 {
   "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
-  "ANTHROPIC_AUTH_TOKEN": "token123",
-  "ANTHROPIC_MODEL": "glm-4.7"
+  "ANTHROPIC_AUTH_TOKEN": "token123"
 }
 
 // 处理后
 {
   "env": {
-    "MY_CUSTOM_VAR": "value"    // 保留（非 ANTHROPIC_* 且非 provider key）
+    "ANTHROPIC_API_KEY": "user-key",
+    "MY_CUSTOM_VAR": "value"
   }
 }
 ```
@@ -243,10 +242,7 @@ func LoadSettings() (map[string]interface{}, error)
 
 **签名**：
 ```go
-// CleanEnvInSettings removes specific environment variable keys from settings.env.
-// It removes:
-//   1. Keys with specific prefixes (ANTHROPIC_*, CLAUDE_*)
-//   2. Keys that match provider env keys
+// CleanEnvInSettings removes environment variable keys controlled by the current provider.
 // Returns a new map without modifying the input.
 func CleanEnvInSettings(settings map[string]interface{}, providerEnvKeys []string) map[string]interface{}
 ```
@@ -331,7 +327,7 @@ func EnsureStopHook(settings map[string]interface{}, hookCommand string) map[str
   │           merged = DeepMerge(merged, userSettings)  ← userSettings 优先
   │
   ├─→ CleanEnvInSettings(merged, providerEnvKeys)
-  │   └─→ 清空 ANTHROPIC_*, CLAUDE_*, provider env keys
+  │   └─→ 清空 provider env keys
   │
   ├─→ EnsureStopHook(merged, hookCommand)
   │   └─→ 确保 Supervisor Stop hook 存在
@@ -428,7 +424,7 @@ func EnsureStopHook(settings map[string]interface{}, hookCommand string) map[str
 ```json
 {
   "env": {
-    "MY_CUSTOM_VAR": "value"    // 保留（非 ANTHROPIC_* 且非 CLAUDE_* 且非 provider key）
+    "MY_CUSTOM_VAR": "value"    // 保留（非 provider key）
   }
 }
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // stopHookTimeout is the timeout in seconds for the Supervisor Stop hook.
@@ -250,11 +249,7 @@ func LoadSettings() (map[string]interface{}, error) {
 	return settings, nil
 }
 
-// CleanEnvInSettings removes specific environment variable keys from settings.env.
-// It removes:
-//  1. Keys with specific prefixes (ANTHROPIC_*, CLAUDE_*)
-//  2. Keys that match provider env keys
-//
+// CleanEnvInSettings removes environment variable keys controlled by the current provider.
 // Returns a new map without modifying the input.
 func CleanEnvInSettings(settings map[string]interface{}, providerEnvKeys []string) map[string]interface{} {
 	// Deep copy to avoid modifying input
@@ -279,21 +274,9 @@ func CleanEnvInSettings(settings map[string]interface{}, providerEnvKeys []strin
 		keysToRemove[key] = true
 	}
 
-	// Remove keys from env
+	// Remove provider env keys from settings.env
 	for key := range env {
-		shouldRemove := false
-
-		// Check for specific prefixes
-		if strings.HasPrefix(key, "ANTHROPIC_") || strings.HasPrefix(key, "CLAUDE_") {
-			shouldRemove = true
-		}
-
-		// Check for provider env keys
 		if keysToRemove[key] {
-			shouldRemove = true
-		}
-
-		if shouldRemove {
 			delete(env, key)
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -753,34 +753,34 @@ func TestLoadSettings(t *testing.T) {
 }
 
 func TestCleanEnvInSettings(t *testing.T) {
-	t.Run("removes ANTHROPIC_ prefixed keys", func(t *testing.T) {
+	t.Run("keeps ANTHROPIC user env keys when provider does not define them", func(t *testing.T) {
 		settings := map[string]interface{}{
 			"env": map[string]interface{}{
-				"ANTHROPIC_MODEL":    "claude-3.7-sonnet",
-				"ANTHROPIC_BASE_URL": "https://old-url.com",
-				"MY_CUSTOM_VAR":      "value",
+				"ANTHROPIC_API_KEY": "user-key",
+				"ANTHROPIC_MODEL":   "claude-3.7-sonnet",
+				"MY_CUSTOM_VAR":     "value",
 			},
 		}
-		providerEnvKeys := []string{"BASE_URL"}
+		providerEnvKeys := []string{"ANTHROPIC_BASE_URL"}
 
 		result := CleanEnvInSettings(settings, providerEnvKeys)
 
 		env := result["env"].(map[string]interface{})
-		if _, exists := env["ANTHROPIC_MODEL"]; exists {
-			t.Error("ANTHROPIC_MODEL should be removed")
+		if env["ANTHROPIC_API_KEY"] != "user-key" {
+			t.Error("ANTHROPIC_API_KEY should be kept")
 		}
-		if _, exists := env["ANTHROPIC_BASE_URL"]; exists {
-			t.Error("ANTHROPIC_BASE_URL should be removed")
+		if env["ANTHROPIC_MODEL"] != "claude-3.7-sonnet" {
+			t.Error("ANTHROPIC_MODEL should be kept")
 		}
-		if _, exists := env["MY_CUSTOM_VAR"]; !exists {
+		if env["MY_CUSTOM_VAR"] != "value" {
 			t.Error("MY_CUSTOM_VAR should be kept")
 		}
 	})
 
-	t.Run("removes CLAUDE_ prefixed keys", func(t *testing.T) {
+	t.Run("keeps CLAUDE_CODE user env keys", func(t *testing.T) {
 		settings := map[string]interface{}{
 			"env": map[string]interface{}{
-				"CLAUDE_MODEL": "claude-3",
+				"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":     "1",
 				"CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
 				"MY_CUSTOM_VAR": "value",
 			},
@@ -790,13 +790,13 @@ func TestCleanEnvInSettings(t *testing.T) {
 		result := CleanEnvInSettings(settings, providerEnvKeys)
 
 		env := result["env"].(map[string]interface{})
-		if _, exists := env["CLAUDE_MODEL"]; exists {
-			t.Error("CLAUDE_MODEL should be removed")
+		if env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] != "1" {
+			t.Error("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS should be kept")
 		}
-		if _, exists := env["CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR"]; exists {
-			t.Error("CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR should be removed")
+		if env["CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR"] != "1" {
+			t.Error("CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR should be kept")
 		}
-		if _, exists := env["MY_CUSTOM_VAR"]; !exists {
+		if env["MY_CUSTOM_VAR"] != "value" {
 			t.Error("MY_CUSTOM_VAR should be kept")
 		}
 	})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -77,9 +77,6 @@ func SwitchWithHook(cfg *config.Config, providerName string) (*SwitchResult, err
 	// This also sets disableAllHooks and allowManagedHooksOnly to false
 	settingsWithHook = config.EnsureStopHook(settingsWithHook, hookCommand)
 
-	// Remove env from settings before saving (provider env is passed via command line)
-	delete(settingsWithHook, "env")
-
 	// Save merged settings to settings.json
 	settingsPath := config.GetSettingsPath()
 	settingsData, err := json.MarshalIndent(settingsWithHook, "", "  ")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -96,9 +96,34 @@ func TestSwitchWithHook(t *testing.T) {
 			t.Errorf("API_TIMEOUT = %v, want 30000", envMap["API_TIMEOUT"])
 		}
 
-		// Verify settings does not contain env
-		if _, exists := result.Settings["env"]; exists {
-			t.Error("Settings should not contain 'env' field")
+		// Verify settings does not contain provider env but contains user env
+		settingsEnv, exists := result.Settings["env"]
+		if !exists {
+			t.Fatal("Settings should contain 'env' field")
+		}
+		
+		settingsEnvMap, ok := settingsEnv.(map[string]interface{})
+		if !ok {
+			t.Fatal("env should be a map")
+		}
+		
+		// Should not contain provider env variables
+		if _, exists := settingsEnvMap["ANTHROPIC_BASE_URL"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_BASE_URL")
+		}
+		if _, exists := settingsEnvMap["ANTHROPIC_AUTH_TOKEN"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_AUTH_TOKEN")
+		}
+		if _, exists := settingsEnvMap["ANTHROPIC_MODEL"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_MODEL")
+		}
+		
+		// Should contain user env variables
+		if settingsEnvMap["API_TIMEOUT"] != "30000" {
+			t.Error("Settings should contain user API_TIMEOUT")
+		}
+		if settingsEnvMap["DISABLE_TELEMETRY"] != "1" {
+			t.Error("Settings should contain user DISABLE_TELEMETRY")
 		}
 
 		// Verify hooks are present

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -111,6 +111,9 @@ func TestSwitchWithHook(t *testing.T) {
 		if _, exists := settingsEnvMap["ANTHROPIC_BASE_URL"]; exists {
 			t.Error("Settings should not contain provider ANTHROPIC_BASE_URL")
 		}
+		if _, exists := settingsEnvMap["ANTHROPIC_API_KEY"]; exists {
+			t.Error("Settings should not contain provider ANTHROPIC_API_KEY")
+		}
 		if _, exists := settingsEnvMap["ANTHROPIC_AUTH_TOKEN"]; exists {
 			t.Error("Settings should not contain provider ANTHROPIC_AUTH_TOKEN")
 		}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -101,12 +101,12 @@ func TestSwitchWithHook(t *testing.T) {
 		if !exists {
 			t.Fatal("Settings should contain 'env' field")
 		}
-		
+
 		settingsEnvMap, ok := settingsEnv.(map[string]interface{})
 		if !ok {
 			t.Fatal("env should be a map")
 		}
-		
+
 		// Should not contain provider env variables
 		if _, exists := settingsEnvMap["ANTHROPIC_BASE_URL"]; exists {
 			t.Error("Settings should not contain provider ANTHROPIC_BASE_URL")
@@ -120,7 +120,7 @@ func TestSwitchWithHook(t *testing.T) {
 		if _, exists := settingsEnvMap["ANTHROPIC_MODEL"]; exists {
 			t.Error("Settings should not contain provider ANTHROPIC_MODEL")
 		}
-		
+
 		// Should contain user env variables
 		if settingsEnvMap["API_TIMEOUT"] != "30000" {
 			t.Error("Settings should contain user API_TIMEOUT")


### PR DESCRIPTION
## Summary
- Preserve user-managed `ANTHROPIC_*` and `CLAUDE_*` env settings unless the active provider defines the same key
- Simplify env cleanup to remove only provider env key conflicts
- Update merge strategy docs and regression tests for the narrower cleanup behavior

## Test plan
- [x] `go test ./internal/config ./internal/provider`
- [x] `./check.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)