### PR TITLE
fix: hard guard for settings.json env conflicts

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -104,13 +104,24 @@ ccc validate --all
 - ✅ 用户安装的插件（`enabledPlugins`）- 不会被覆盖
 - ✅ 手动编辑的 `settings.json`（权限、沙箱等）- 完全保留
 - ✅ 用户配置的其他 hooks（PreToolUse、SessionStart 等）- 被尊重
-- ✅ 用户在 `settings.json` 中手动设置的环境变量 - 不会被删除（除了冲突，见下文）
+- ✅ 用户在 `settings.json` 中手动设置的环境变量 - ccc 不会修改
 
 #### 管理的内容
 
 - 🤖 Supervisor Stop hook - 自动添加/确保
-- 🧹 环境变量冲突 - `ANTHROPIC_*`、`CLAUDE_*` 和提供商 env 键从 `settings.json` 中移除以避免歧义
 - ⚙️ Hook 执行标志 - `disableAllHooks` 和 `allowManagedHooksOnly` 设置为 `false` 以确保 hooks 能正常工作
+
+#### 环境变量冲突（硬守卫）
+
+Claude Code 的 `settings.json` `env` 字段会**覆盖**ccc 启动 claude 时传入的环境变量（实测已验证）。如果 `settings.json` 中存在会遮蔽 provider env 的 key，切换 provider 会静默失效（用错 base_url / token / model）。
+
+**当检测到此类冲突时，ccc 会拒绝启动 claude，`ccc validate` 同样会被拒绝。** ccc 不会静默修改你的文件，而是会打印冲突的 key（不打印 value，避免泄露密钥）并告诉你如何修复。**ccc 不会修改你 `settings.json` 的 `env` 字段。**
+
+满足以下任一条件的 key 视为冲突：
+- 以 `ANTHROPIC_` 或 `CLAUDE_` 开头，**或**
+- 与 ccc.json 中 base / provider `env` 定义的任何 key 同名。
+
+**修复方法**：从 `~/.claude/settings.json` 的 `env` 中删除这些 key，并把 provider 相关配置改到 `~/.claude/ccc.json` 的 `providers.<name>.env` 中。
 
 #### 工作原理
 

--- a/README.md
+++ b/README.md
@@ -161,13 +161,24 @@ Config file location, default: `~/.claude/ccc.json`
 - ✅ User-installed plugins (`enabledPlugins`) - never overwritten
 - ✅ Manual `settings.json` edits (permissions, sandbox, etc.) - fully preserved
 - ✅ User-configured hooks (PreToolUse, SessionStart, etc.) - respected
-- ✅ Environment variables you manually set in settings.json - not removed (except for conflicts, see below)
+- ✅ Environment variables you manually set in settings.json - ccc never edits them
 
 #### What Gets Managed
 
 - 🤖 Supervisor Stop hook - automatically added/ensured
-- 🧹 Environment variable conflicts - `ANTHROPIC_*`, `CLAUDE_*`, and provider env keys are removed from `settings.json` to avoid ambiguity
 - ⚙️ Hook execution flags - `disableAllHooks` and `allowManagedHooksOnly` set to `false` to ensure hooks work
+
+#### Environment Variable Conflicts (Hard Guard)
+
+Claude Code's `settings.json` `env` field **overrides** environment variables passed by ccc when launching claude (empirically verified). If `settings.json` contains keys that would shadow the provider env, switching providers silently fails (wrong base_url / token / model).
+
+**ccc refuses to start claude — and refuses to run `ccc validate` — when it detects such conflicts.** Instead of silently editing your file, ccc prints the offending keys (without their values, to avoid leaking secrets) and tells you how to fix it. ccc never modifies the `env` field of your `settings.json`.
+
+A key is considered conflicting if it:
+- starts with `ANTHROPIC_` or `CLAUDE_`, **or**
+- collides with any key defined in ccc.json's base / provider `env`.
+
+**How to fix:** remove those keys from `~/.claude/settings.json`'s `env` and move provider-related configuration into `providers.<name>.env` in `~/.claude/ccc.json`.
 
 #### How It Works
 

--- a/docs/discuss-20260519-env-priority.md
+++ b/docs/discuss-20260519-env-priority.md
@@ -1,0 +1,179 @@
+# 讨论：env 优先级问题排查（PR #79）
+
+日期：2026-05-19
+话题：核实 ccc 切换 provider 时 env 的生效优先级，评估 PR #79 的方案是否安全。
+触发：https://github.com/guyskk/claude-code-supervisor/pull/79
+
+> 本文件 Append-only，只追加不覆盖。
+
+---
+
+## 第 1 轮：背景探索与关键发现
+
+### 1.1 PR #79 是什么
+
+- PR #79 标题：`Preserve user env settings during provider switch`
+- 分支：`fix/preserve-user-env-in-settings`，head = `a251cbf`
+- 状态：**OPEN，CONFLICTING / DIRTY**（与 main 冲突）
+- 目标：解决"切换 provider 时把用户在 settings.json 里手动配置的 env 抹掉"的问题（Issue #74 类问题）。
+
+PR #79 的代码改动（针对它的 base）：
+1. `CleanEnvInSettings`：从「移除 `ANTHROPIC_*`/`CLAUDE_*` 前缀 + provider 同名 key」收窄为「只移除 provider 同名 key」，即**保留用户的 `ANTHROPIC_*`/`CLAUDE_*` 自定义 env**。
+2. `provider.go`：删除 `delete(settingsWithHook, "env")`，即**不再清空 settings.json 的 env，让合并后的 env 留在 settings.json**。
+
+### 1.2 关键发现：PR #79 已与 main 分叉，且 main 已用另一套方案修复
+
+- `git merge-base main pr79` = `8f0bf0c`（PR #73 合并点）。
+- PR #79 从 `8f0bf0c` 拉出，但 main 之后已经走了 **PR #76（commit `c71511a` "fix: preserve user-defined env in settings.json"）**，针对**同一个问题**做了**另一套修复**。
+- 因此 PR #79 与 main 是**针对同一问题的两个独立方案**，PR #79 是陈旧的、与已合并的 #76 冲突的备选方案。
+- PR #79 diff 里还在改 `CleanEnvInSettings`，但 main 上该函数**已被 #76 删除**——这就是冲突来源。
+
+### 1.3 当前 main（已含 #76）的 env 处理逻辑（实际代码确认）
+
+`internal/provider/provider.go` `SwitchWithHook()`（行 37-121）：
+- 分别提取三个来源的 env：`userEnvMap`（settings.json）、`baseEnvMap`（ccc.json settings）、`providerEnvMap`（ccc.json provider）。
+- `managedEnvKeys` = base env keys + provider env keys。
+- `MergeWithPriority(base, provider, user)` 深合并（user > provider > base）。
+- `EnsureStopHook` 注入 Supervisor Stop hook。
+- **`delete(settingsWithHook, "env")`** 然后写回 `FilterUserEnvForSettings(userEnvMap, managedEnvKeys)`。
+- 子进程 env = `MergeEnvMaps(baseEnvMap, providerEnvMap)`（**只有 base + provider，不含 user env**）。
+
+`internal/config/config.go` `FilterUserEnvForSettings()`（行 256-276）：
+- 写入 settings.json 的 env：跳过 `managedEnvKeys`，并且**跳过所有 `ANTHROPIC_*` / `CLAUDE_*` 前缀 key**。
+- 结论：当前 main 下，**settings.json 的 env 永远不含 `ANTHROPIC_*`/`CLAUDE_*`**，因此 settings.json 与 provider env 不可能在这些 key 上冲突。
+
+`internal/cli/exec.go` `runClaude()`（行 129-151）：
+- `env := os.Environ()` 复制 ccc 进程环境。
+- 过滤掉所有 `CLAUDE_*` / `ANTHROPIC_*` 前缀的进程 env（保证 provider 优先）。
+- 追加 `switchResult.EnvVars`（= base + provider env）。
+- `syscall.Exec(claudePath, args, env)` 用该环境替换为 claude 进程。
+
+### 1.4 待验证的核心未知
+
+官方文档 `docs/claude-code-settings.md` 说明了 settings 作用域优先级（managed > user > project），但**没有说明 settings.json 的 `env` 字段与「claude 进程实际继承的 OS 环境变量」谁优先**。
+
+这是决定 PR #79 方案是否安全的关键问题：
+- 若 **settings.json `env` 覆盖进程 env**：PR #79 保留用户旧的 `ANTHROPIC_BASE_URL` 在 settings.json 里，会**压过命令行传入的 provider env**，导致**切换 provider 失效**（用错 base url / token）。这是严重 bug。
+- 若 **进程 env 覆盖 settings.json `env`**：PR #79 相对安全，provider env 仍生效，settings.json 里的旧 env 只在 provider 未定义该 key 时兜底。
+
+**下一步：用 claude 实测这个优先级。**
+
+---
+
+## 第 2 轮：实测验证（claude 2.1.144，隔离环境 CLAUDE_CONFIG_DIR=./tmp/claude-home）
+
+三个实验，settings.json 端口/值 vs 进程 env 端口/值，互为对照：
+
+### 实验 A — 中性变量，经 Bash 工具观测
+- settings.json: `CCC_PRECEDENCE_TEST=VALUE_FROM_SETTINGS_JSON`
+- 进程 env: `CCC_PRECEDENCE_TEST=VALUE_FROM_PROCESS_ENV`
+- `claude -p "printenv CCC_PRECEDENCE_TEST"` 输出：**`VALUE_FROM_SETTINGS_JSON`**
+- → settings.json env 覆盖进程 env。
+
+### 实验 B（决定性）— ANTHROPIC_BASE_URL，观测 claude 真实 API 连接目标
+- settings.json: `ANTHROPIC_BASE_URL=http://127.0.0.1:19991`
+- 进程 env: `ANTHROPIC_BASE_URL=http://127.0.0.1:19992`
+- 双端口监听器结果：**`HIT port=19991 (SETTINGS_JSON)`**
+- → 连 claude 自己发 API 用的 `ANTHROPIC_BASE_URL`，settings.json 也覆盖进程 env。
+
+### 实验 C — settings.json 无 env（模拟当前 main 经 FilterUserEnvForSettings 剥离后的状态）
+- settings.json: 无 env
+- 进程 env: `ANTHROPIC_BASE_URL=http://127.0.0.1:19992`
+- 结果：**`HIT port=19992 (PROCESS_ENV)`**
+- → settings.json 不含该 key 时，进程 env（= ccc 传入的 provider env）才生效。
+
+### 实测结论（确定）
+
+**Claude Code 中：settings.json 的 `env` 严格覆盖 claude 进程继承的 OS 环境变量。**
+ccc 用 `syscall.Exec` 传入的 provider env 属于"进程环境变量"层级，**优先级低于 settings.json 的 env**。
+
+### 对三个问题的回答
+
+1. **env 优先级**：`settings.json.env` > 进程 env（ccc 命令行传入的 provider env）。仅当 settings.json 不含该 key 时，进程 env 兜底生效。
+2. **哪里的 env 生效**：settings.json 里有 `ANTHROPIC_BASE_URL` 就用它；没有才用 ccc 传入的 provider 值。
+3. **启动时不清除 settings.json 的 env 是否有问题**：**是，严重问题**。因 settings.json env 压过进程 env，ccc 靠进程 env 传 provider 配置会被 settings.json 里残留的旧 `ANTHROPIC_*` 覆盖 → **切换 provider 静默失效**（用错 base_url / token / model）。
+
+### 对 #76（当前 main）与 #79 的判断
+
+- **当前 main（#76）方案正确**：`FilterUserEnvForSettings` 把所有 `ANTHROPIC_*`/`CLAUDE_*` 及 base/provider managed key 一律从 settings.json 剔除 → settings.json 永不含这些 key → provider env 经进程 env 必然生效（实验 C 证明）。同时保留用户非冲突、非 `ANTHROPIC_*`/`CLAUDE_*` 的自定义 env（实验思路同 A，那类 key 会被保留并生效，正是用户想要的）。
+- **PR #79 方案不安全，不应合并**：
+  - 它只移除"与当前 provider 同名的 key"，**保留用户的 `ANTHROPIC_*`/`CLAUDE_*`**；并删除 `delete(settingsWithHook,"env")`。
+  - 后果：provider 未覆盖的 `ANTHROPIC_*`（如 `ANTHROPIC_MODEL`、`ANTHROPIC_SMALL_FAST_MODEL`）或切换 provider 后 settings.json 残留的旧值，会留在 settings.json 并**覆盖**命令行传入的 provider env → 切 provider 失效 / 模型错乱。
+  - 附带：provider token 被持久化写入 settings.json 文件（安全 & 陈旧问题）。
+  - PR #79 想解决的真实诉求（用户手动配的非 provider env 不该被抹掉）**已被 #76 满足**。
+- **建议**：PR #79 关闭（其诉求已由 #76 覆盖），不需要再改代码；若发现 #76 仍有未覆盖边界，应基于 main 现状重新评估，而非合并 #79。
+
+---
+
+## 第 3 轮：用户决策与"迁移 + 提示"方案设计
+
+### 用户决策
+
+1. **PR #79 已关闭**（已执行 `gh pr close 79`，附实测说明评论）。
+2. 用户认可"#76 会丢失用户手动配的 `ANTHROPIC_*`/`CLAUDE_*`"是真实问题，要求：把这些 key **迁移到 ccc.json**（不丢失），并且**打断用户给出提示**（不静默），更稳妥。
+
+### #76 现状复核（确认丢失问题真实存在）
+
+`FilterUserEnvForSettings`（config.go:256）对 `managedEnvKeys` 命中 或 `ANTHROPIC_*`/`CLAUDE_*` 前缀的 key 一律 `continue` → 既不写回 settings.json，也不进子进程 env（子进程 env = `MergeEnvMaps(base, provider)`，不含 user）。结论：用户手动配的全局 `CLAUDE_CODE_*` 等，跑一次 ccc 后**永久丢失且失效**。迁移方案方向正确。
+
+### 现有提示/迁移机制（用于风格对齐）
+
+- `internal/migration/migration.go`：`GetUserInputFunc`（stdin `bufio.Reader`，测试可覆盖）、`PromptUser()`（`[y/N]`）、`MigrateFromSettings()`。
+- 触发点 `internal/cli/cli.go:280-297`：**仅在首次运行（ccc.json 不存在、`config.Load()` 报错）** 时提示迁移，把整个 settings.json 转成 ccc.json 的 `default` provider。
+- 这与本需求不同：本需求是**每次运行**都要检测 settings.json 里是否残留 `ANTHROPIC_*`/`CLAUDE_*`（ccc.json 已存在的常规场景），需新增独立的检测+提示+迁移逻辑，挂在启动路径（`runClaude` / `SwitchWithHook` 之前）。
+
+### 提示方案设计（待对齐）
+
+**触发条件**：启动 claude 前，`LoadSettings()` 得到的 user settings.json `env` 中存在任何 `ANTHROPIC_*`/`CLAUDE_*` 或命中 `managedEnvKeys` 的 key。
+
+**交互内容**：列出检测到的这些 key，说明 WHY（settings.json 的 env 会覆盖 ccc 经命令行传入的 provider env，导致切换 provider 失效，已实测证明），给出迁移计划，`[Y/n]` 确认。
+
+**迁移目标分类**（仍建议区分，避免凭据串台）：
+- 凭据/端点/模型类（黑名单：`ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_API_KEY`/`ANTHROPIC_MODEL`/`ANTHROPIC_SMALL_FAST_MODEL`）：**不进 base**（进 base 会被所有 provider 继承，旧端点/模型串台/陈旧）。提示建议用户改用 provider 配置；ccc 这里仅从 settings.json 移除。
+- 其余 `ANTHROPIC_*`/`CLAUDE_*` 行为开关类：迁入 `ccc.json.settings.env`（base 模板），既不丢失又继续生效，且 settings.json 仍被清空（实验 C 保证切换正确）。
+
+**幂等**：迁移后 settings.json 不再含这些 key → 后续运行不再触发提示（除非用户又手动加回，此时再次提示，因稀少不扰民）。
+
+### 必须与用户对齐的关键设计点（阻塞项）
+
+1. **非交互场景兜底**：supervisor 模式会重入 ccc（`CCC_SUPERVISOR_ID` 已设）、`ccc -p`、CI、stdin 非 TTY —— **绝不能在这些路径上阻塞等待输入**。兜底策略二选一：
+   - (a) 回退到 #76 行为（剥离丢弃，切换仍正确，但丢全局偏好）；
+   - (b) 静默执行同样的"选择性迁移"+ stderr 一行提示（不丢失，推荐）。
+2. **用户拒绝（选 n）时的行为**：(a) 中止 ccc 不启动 claude，让用户自行处理；(b) 仍按 #76 安全剥离后继续启动（保证切换正确，但本次仍丢偏好）。
+3. **凭据黑名单**是否认可？`ANTHROPIC_MODEL`/`ANTHROPIC_SMALL_FAST_MODEL` 是否也算 provider 专属（不进 base）？
+4. **base 已存在同名 key**时，迁移是否以 settings.json 的值覆盖 base？
+5. `ccc validate` 路径是否也要触发提示？（建议不触发，仅启动路径触发）
+
+---
+
+## 第 4 轮：最终决策（方案大幅简化为"硬守卫，无交互"）
+
+用户多轮明确指示，最终方案锁定：
+
+1. **不迁移、不帮用户改任何配置**。配置冲突是 ccc 解决不了的，交给用户自己处理。
+2. **不剥离、不静默继续**（这是对 #76 当前"静默 strip 后继续"行为的明确改变）。
+3. **无交互、无 y/N**：检测到冲突 → **直接报错提示并中止，不启动 claude**。交互与非交互行为一致。
+4. **报错信息必须包含**：冲突的具体 key 列表；原因（settings.json 的 `env` 覆盖 ccc 经命令行传入的 provider env，已实测证明，会导致切换 provider 失效）；用户自己的修复方法（从 `~/.claude/settings.json` 的 `env` 删除这些 key；provider 相关配置改在 `~/.claude/ccc.json` 里配）。
+5. **作用范围**：正常启动路径 + `ccc validate` 都要做此检测。
+6. **检测判据**：settings.json 的 `env` 中存在 `ANTHROPIC_*` / `CLAUDE_*` 前缀 key，或与 base/provider env 同名的 managed key。非冲突的用户自定义 env（如 `MY_CUSTOM_VAR`）不受影响、允许保留。
+
+### 行为变化说明（实施时需注意）
+
+- #76 的 `FilterUserEnvForSettings` 当前承担"静默剥离 `ANTHROPIC_*`/`CLAUDE_*`/managed key"的职责并继续运行；新方案下，命中即**中止**，不会走到剥离继续的逻辑。剥离逻辑是否保留/简化属计划阶段细节（因为中止后 settings.json 仍由用户保有原样，不再被 ccc 改写这些 key）。
+- 这是一个**破坏性行为变化**：原本能跑（静默丢配置）的场景，现在会被拦下要求用户先清理 settings.json。需在 README / docs/settings-merge-strategy.md 同步说明。
+
+### 状态：需求与方案已完全对齐，无遗留疑问，待用户给出进入计划模式的指令。
+
+---
+
+## 第 5 轮：用户批准，进入计划模式
+
+用户回复"好"，确认方案。补充探索确认的集成点：
+- 启动路径：`internal/cli/exec.go` `runClaude()`，应在 `provider.SwitchWithHook()` 之前做守卫检测。
+- 校验路径：`internal/cli/cli.go` `runValidate()` 持有完整 `*config.Config`，应在调用 `validate.Run()` 之前做同样检测（`validate.Config` 接口仅暴露 `Providers()`/`CurrentProvider()`，故守卫放 `runValidate` 内最简单）。
+- 检测逻辑应作为 `internal/config` 的导出函数（如 `DetectEnvConflicts`），供两处复用，附错误信息格式化。
+- managedEnvKeys = base env keys ∪ provider env keys；判据 = `ANTHROPIC_*`/`CLAUDE_*` 前缀 ∨ 命中 managedEnvKeys。
+- TDD：检测函数有逻辑，需单测；两处集成点行为需测试。
+- 文档：README.md / README-CN.md / docs/settings-merge-strategy.md 同步破坏性变化。
+
+进入计划模式编写详细 Plan。

--- a/docs/settings-merge-strategy.md
+++ b/docs/settings-merge-strategy.md
@@ -71,24 +71,23 @@ ccc 不应该：
 
 ## 字段处理策略
 
-### 1. env 字段 - 分离处理
+### 1. env 字段 - 硬守卫（不再自动剥离）
 
-**处理方式**：区分"用户 env"和"ccc env"，分别写入 settings.json 和子进程。
+**当前策略**：检测到冲突即报错中止，ccc 永不修改 settings.json 的 `env` 字段。
 
-**写入 settings.json 的 env**：
-- 只保留用户在 settings.json 中定义的 env key
-- 排除与 base/provider env 冲突的 key
-- 排除 `ANTHROPIC_*`/`CLAUDE_*` 前缀的 key
-- 如果过滤后为空，不写 env 字段
+> **破坏性变化（2026-05-19 更新）**：早期版本会静默剥离 settings.json `env` 中的 `ANTHROPIC_*`/`CLAUDE_*` 或与 provider/base 同名的 key。实测确认 Claude Code 中 `settings.json` 的 `env` 严格覆盖进程 env，因此残留任何冲突 key 都会导致切换 provider 静默失效。当前实现改为**硬守卫**：检测到冲突就直接报错中止（不启动 claude，也不放行 `ccc validate`），由用户自行清理 settings.json，避免静默丢配置或静默用错配置两种风险。详见 `docs/discuss-20260519-env-priority.md`。
 
-**传递给子进程的 env**：
-- 只包含 base + provider 的 env
-- 不包含用户 settings.json 的 env（Claude Code 自己从 settings.json 读取）
+**冲突判据**（命中任一即冲突）：
+- key 以 `ANTHROPIC_` 或 `CLAUDE_` 开头；
+- key 与 base env（`ccc.json` 的 `settings.env`）或 provider env（`ccc.json` 的 `providers.<name>.env`）同名（managed key）。
 
-**原因**：
-- provider 的环境变量通过命令行传递给 claude 子进程
-- 用户自定义的非冲突 env 需要保留在 settings.json 中供 Claude Code 使用
-- 子进程只需 base + provider env，避免重复
+**冲突报错**：列出每个冲突 key 的名称（**不打印 value，避免密钥泄露**）、原因、settings.json / ccc.json 文件路径、以及修复指引（用户自行从 settings.json 删除冲突 key，provider 配置移到 ccc.json）。
+
+**传递给子进程的 env**（无冲突时的正常路径）：
+- 只包含 base + provider 的 env；
+- 不包含用户 settings.json 的 env（Claude Code 自己从 settings.json 读取非冲突的用户自定义 env）。
+
+**非冲突的用户自定义 env**（如 `MY_CUSTOM_VAR`）：完全保留在 settings.json 中、不被修改、不被进入子进程合并 env，行为不变。
 
 **示例**：
 
@@ -97,42 +96,18 @@ ccc 不应该：
 {
   "env": {
     "ANTHROPIC_MODEL": "claude-3.7-sonnet",
-    "MY_CUSTOM_VAR": "value",
-    "DISABLE_TELEMETRY": "1"
+    "MY_CUSTOM_VAR": "value"
   }
-}
-
-// base env
-{
-  "API_TIMEOUT": "30000",
-  "DISABLE_TELEMETRY": "1"
 }
 
 // provider env
 {
   "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
-  "ANTHROPIC_AUTH_TOKEN": "token123",
-  "ANTHROPIC_MODEL": "glm-4.7"
-}
-
-// 写入 settings.json 的 env
-{
-  "env": {
-    "MY_CUSTOM_VAR": "value"    // 保留（非冲突、非 ANTHROPIC_*/CLAUDE_*）
-  }
-  // DISABLE_TELEMETRY 被过滤（与 base env 冲突）
-  // ANTHROPIC_MODEL 被过滤（ANTHROPIC_* 前缀）
-}
-
-// 传递给子进程的 env（base + provider）
-{
-  "API_TIMEOUT": "30000",
-  "DISABLE_TELEMETRY": "1",
-  "ANTHROPIC_BASE_URL": "https://open.bigmodel.cn/api/anthropic",
-  "ANTHROPIC_AUTH_TOKEN": "token123",
   "ANTHROPIC_MODEL": "glm-4.7"
 }
 ```
+
+**结果**：ccc 检测到 `ANTHROPIC_MODEL` 冲突 → 报错中止，settings.json 保持原样，由用户决定是删除该 key 还是把 `ANTHROPIC_MODEL` 留作个人偏好（删除后即生效 provider 值）。`MY_CUSTOM_VAR` 不受影响。
 
 ---
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -306,6 +306,13 @@ func Run(cmd *Command) error {
 
 // runValidate executes the validate command.
 func runValidate(cfg *config.Config, opts *ValidateCommand) error {
+	// Guard: refuse to validate when settings.json contains env keys that would
+	// silently override provider env. The check mirrors the launch-path guard so
+	// users get the same actionable error from both entry points.
+	if err := checkValidateEnvConflict(cfg, opts); err != nil {
+		return err
+	}
+
 	// Create a config adapter for the validate package
 	cfgAdapter := &configAdapter{cfg: cfg}
 
@@ -315,6 +322,76 @@ func runValidate(cfg *config.Config, opts *ValidateCommand) error {
 	}
 
 	return validate.Run(cfgAdapter, validateOpts)
+}
+
+// checkValidateEnvConflict runs the same env-conflict guard used by runClaude, scoped
+// to the providers about to be validated:
+//   - --all: union of base env + every provider's env (from-strictest stance).
+//   - --provider X (or current): base env + provider X's env.
+//
+// Returns nil when no conflicts, a formatted error otherwise.
+func checkValidateEnvConflict(cfg *config.Config, opts *ValidateCommand) error {
+	userSettings, err := config.LoadSettings()
+	if err != nil {
+		return fmt.Errorf("failed to load settings.json for conflict check: %w", err)
+	}
+	if userSettings == nil {
+		return nil
+	}
+
+	managedEnvKeys := make(map[string]bool)
+	for key := range config.GetEnv(cfg.Settings) {
+		managedEnvKeys[key] = true
+	}
+
+	providerNames := validateTargetProviders(cfg, opts)
+	for _, name := range providerNames {
+		providerSettings, ok := cfg.Providers[name]
+		if !ok {
+			continue
+		}
+		for key := range config.GetEnv(providerSettings) {
+			managedEnvKeys[key] = true
+		}
+	}
+
+	conflicts := config.DetectSettingsEnvConflicts(userSettings, managedEnvKeys)
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%s", config.FormatEnvConflictError(
+		config.GetSettingsPath(),
+		config.GetConfigPath(),
+		conflicts,
+	))
+}
+
+// validateTargetProviders returns the provider names whose env keys should contribute
+// to managedEnvKeys for the validate guard. For --all (or when a specific provider is
+// not provided and there's no current provider), it returns every configured provider.
+func validateTargetProviders(cfg *config.Config, opts *ValidateCommand) []string {
+	if opts.ValidateAll {
+		names := make([]string, 0, len(cfg.Providers))
+		for name := range cfg.Providers {
+			names = append(names, name)
+		}
+		return names
+	}
+
+	name := opts.Provider
+	if name == "" {
+		name = cfg.CurrentProvider
+	}
+	if name == "" {
+		// No target identifiable: treat as --all to stay strict.
+		names := make([]string, 0, len(cfg.Providers))
+		for n := range cfg.Providers {
+			names = append(names, n)
+		}
+		return names
+	}
+	return []string{name}
 }
 
 // configAdapter adapts config.Config to the validate.Config interface.

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -20,6 +20,49 @@ func executeProcess(path string, args []string, env []string) error {
 	return syscall.Exec(path, args, env)
 }
 
+// checkSettingsEnvConflict refuses to start claude when settings.json's env field
+// contains keys that would silently override the provider env ccc passes to claude.
+// See docs/discuss-20260519-env-priority.md for the empirical proof that settings.json
+// env > process env in Claude Code.
+//
+// managedEnvKeys are derived from base env (cfg.Settings.env) plus the active
+// provider's env. A non-nil error means the user must clean settings.json before ccc
+// will launch claude — ccc never modifies the user's settings.json on their behalf.
+func checkSettingsEnvConflict(cfg *config.Config, providerName string) error {
+	providerSettings, ok := cfg.Providers[providerName]
+	if !ok {
+		// Provider lookup failure is surfaced later by SwitchWithHook; we just skip the guard.
+		return nil
+	}
+
+	userSettings, err := config.LoadSettings()
+	if err != nil {
+		return fmt.Errorf("failed to load settings.json for conflict check: %w", err)
+	}
+	if userSettings == nil {
+		return nil
+	}
+
+	managedEnvKeys := make(map[string]bool)
+	for key := range config.GetEnv(cfg.Settings) {
+		managedEnvKeys[key] = true
+	}
+	for key := range config.GetEnv(providerSettings) {
+		managedEnvKeys[key] = true
+	}
+
+	conflicts := config.DetectSettingsEnvConflicts(userSettings, managedEnvKeys)
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%s", config.FormatEnvConflictError(
+		config.GetSettingsPath(),
+		config.GetConfigPath(),
+		conflicts,
+	))
+}
+
 // determineProvider determines which provider to use based on the command and config.
 func determineProvider(cmd *Command, cfg *config.Config) string {
 	if cmd.Provider != "" {
@@ -60,6 +103,14 @@ func runClaude(cfg *config.Config, cmd *Command) error {
 	providerName := determineProvider(cmd, cfg)
 	if providerName == "" {
 		return fmt.Errorf("no providers configured")
+	}
+
+	// Guard: refuse to start claude when settings.json contains env keys that
+	// would silently override the provider env ccc passes to the claude process.
+	// Must run BEFORE SwitchWithHook so we never rewrite settings.json while leaving
+	// the conflict in place. See docs/discuss-20260519-env-priority.md.
+	if err := checkSettingsEnvConflict(cfg, providerName); err != nil {
+		return err
 	}
 
 	// Check if supervisor ID is already set in environment

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/guyskk/ccc/internal/config"
+)
+
+// writeSettingsJSON writes a settings.json into the test config dir.
+func writeSettingsJSON(t *testing.T, content string) {
+	t.Helper()
+	path := filepath.Join(config.GetDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+}
+
+func TestCheckSettingsEnvConflict_NoSettingsFile(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {
+				"env": map[string]interface{}{
+					"ANTHROPIC_BASE_URL":   "https://example.com",
+					"ANTHROPIC_AUTH_TOKEN": "sk-x",
+				},
+			},
+		},
+	}
+
+	if err := checkSettingsEnvConflict(cfg, "glm"); err != nil {
+		t.Errorf("expected no error when settings.json missing, got: %v", err)
+	}
+}
+
+func TestCheckSettingsEnvConflict_NoConflict(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	writeSettingsJSON(t, `{"env":{"MY_CUSTOM_VAR":"value"}}`)
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {
+				"env": map[string]interface{}{
+					"ANTHROPIC_BASE_URL":   "https://example.com",
+					"ANTHROPIC_AUTH_TOKEN": "sk-x",
+				},
+			},
+		},
+	}
+
+	if err := checkSettingsEnvConflict(cfg, "glm"); err != nil {
+		t.Errorf("expected no error when only safe custom env present, got: %v", err)
+	}
+}
+
+func TestCheckSettingsEnvConflict_PrefixHit(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	writeSettingsJSON(t, `{"env":{"ANTHROPIC_BASE_URL":"https://old.example.com"}}`)
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {
+				"env": map[string]interface{}{
+					"ANTHROPIC_BASE_URL":   "https://new.example.com",
+					"ANTHROPIC_AUTH_TOKEN": "sk-x",
+				},
+			},
+		},
+	}
+
+	err := checkSettingsEnvConflict(cfg, "glm")
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_BASE_URL") {
+		t.Errorf("error should mention conflict key, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "https://old.example.com") {
+		t.Errorf("error must not contain user value (leak risk), got: %v", err)
+	}
+}
+
+func TestCheckSettingsEnvConflict_ManagedHit(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	writeSettingsJSON(t, `{"env":{"API_TIMEOUT":"60000"}}`)
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{
+			"env": map[string]interface{}{
+				"API_TIMEOUT": "30000",
+			},
+		},
+		Providers: map[string]map[string]interface{}{
+			"glm": {
+				"env": map[string]interface{}{
+					"ANTHROPIC_BASE_URL":   "https://example.com",
+					"ANTHROPIC_AUTH_TOKEN": "sk-x",
+				},
+			},
+		},
+	}
+
+	err := checkSettingsEnvConflict(cfg, "glm")
+	if err == nil {
+		t.Fatal("expected conflict error for managed key, got nil")
+	}
+	if !strings.Contains(err.Error(), "API_TIMEOUT") {
+		t.Errorf("error should mention conflict key API_TIMEOUT, got: %v", err)
+	}
+}
+
+func TestCheckSettingsEnvConflict_UnknownProvider(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	writeSettingsJSON(t, `{"env":{"ANTHROPIC_BASE_URL":"https://x"}}`)
+
+	cfg := &config.Config{
+		Settings:  map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{},
+	}
+
+	// Unknown provider: guard skips silently, leaves the real error to SwitchWithHook.
+	if err := checkSettingsEnvConflict(cfg, "missing"); err != nil {
+		t.Errorf("expected guard to skip on unknown provider, got: %v", err)
+	}
+}
+
+func TestCheckValidateEnvConflict_NoSettingsFile(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {"env": map[string]interface{}{"ANTHROPIC_BASE_URL": "https://x"}},
+		},
+	}
+
+	if err := checkValidateEnvConflict(cfg, &ValidateCommand{}); err != nil {
+		t.Errorf("expected no error when settings.json missing, got: %v", err)
+	}
+}
+
+func TestCheckValidateEnvConflict_AllProvidersStrict(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	// settings.json only has a key that overlaps with provider "kimi"'s env,
+	// not "glm"'s. With --all the guard must still detect it.
+	writeSettingsJSON(t, `{"env":{"ANTHROPIC_SMALL_FAST_MODEL":"old"}}`)
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {"env": map[string]interface{}{"ANTHROPIC_BASE_URL": "https://glm"}},
+			"kimi": {"env": map[string]interface{}{
+				"ANTHROPIC_BASE_URL":         "https://kimi",
+				"ANTHROPIC_SMALL_FAST_MODEL": "kimi-fast",
+			}},
+		},
+	}
+
+	err := checkValidateEnvConflict(cfg, &ValidateCommand{ValidateAll: true})
+	if err == nil {
+		t.Fatal("expected conflict for ANTHROPIC_SMALL_FAST_MODEL under --all, got nil")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_SMALL_FAST_MODEL") {
+		t.Errorf("error should mention conflict key, got: %v", err)
+	}
+}
+
+func TestCheckValidateEnvConflict_SingleProviderScope(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	// settings.json has ANTHROPIC_BASE_URL which always triggers prefix rule,
+	// regardless of which provider is targeted.
+	writeSettingsJSON(t, `{"env":{"ANTHROPIC_BASE_URL":"https://old"}}`)
+
+	cfg := &config.Config{
+		CurrentProvider: "glm",
+		Settings:        map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {"env": map[string]interface{}{"ANTHROPIC_BASE_URL": "https://glm"}},
+		},
+	}
+
+	err := checkValidateEnvConflict(cfg, &ValidateCommand{Provider: "glm"})
+	if err == nil {
+		t.Fatal("expected conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_BASE_URL") {
+		t.Errorf("error should mention conflict key, got: %v", err)
+	}
+}
+
+func TestCheckValidateEnvConflict_NoConflict(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	writeSettingsJSON(t, `{"env":{"MY_CUSTOM":"x"}}`)
+
+	cfg := &config.Config{
+		Settings: map[string]interface{}{},
+		Providers: map[string]map[string]interface{}{
+			"glm": {"env": map[string]interface{}{"ANTHROPIC_BASE_URL": "https://x"}},
+		},
+	}
+
+	if err := checkValidateEnvConflict(cfg, &ValidateCommand{ValidateAll: true}); err != nil {
+		t.Errorf("expected no error when only safe env present, got: %v", err)
+	}
+}

--- a/internal/config/env_guard.go
+++ b/internal/config/env_guard.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// EnvConflict describes a single env key in settings.json that conflicts with ccc's
+// provider/base env management. Conflicts must be resolved by the user (ccc never
+// modifies settings.json on the user's behalf).
+type EnvConflict struct {
+	// Key is the env variable name found in settings.json's "env" field.
+	Key string
+	// Reason explains why the key is considered a conflict. The text is human-readable
+	// and intended to appear in error messages presented to the user.
+	Reason string
+}
+
+const (
+	reasonAnthropicClaudePrefix = "anthropic/claude prefix"
+	reasonManagedByProvider     = "managed by provider/base"
+)
+
+// DetectSettingsEnvConflicts inspects the env map inside the user's settings.json
+// and returns every key that conflicts with ccc's env management.
+//
+// A key is considered conflicting if either:
+//   - it starts with "ANTHROPIC_" or "CLAUDE_" (these are reserved by Claude Code
+//     itself and will override env passed by ccc via syscall.Exec); or
+//   - it is present in managedEnvKeys (i.e., it is also set in ccc.json's base/provider
+//     env, where the settings.json value would silently override the ccc one).
+//
+// Returns nil when userSettings is nil, contains no "env" field, env is not a map,
+// or no conflicts are found.
+func DetectSettingsEnvConflicts(userSettings map[string]interface{}, managedEnvKeys map[string]bool) []EnvConflict {
+	envMap := GetEnv(userSettings)
+	if envMap == nil {
+		return nil
+	}
+
+	var conflicts []EnvConflict
+	for key := range envMap {
+		if strings.HasPrefix(key, "ANTHROPIC_") || strings.HasPrefix(key, "CLAUDE_") {
+			conflicts = append(conflicts, EnvConflict{Key: key, Reason: reasonAnthropicClaudePrefix})
+			continue
+		}
+		if managedEnvKeys[key] {
+			conflicts = append(conflicts, EnvConflict{Key: key, Reason: reasonManagedByProvider})
+		}
+	}
+
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	sort.Slice(conflicts, func(i, j int) bool {
+		return conflicts[i].Key < conflicts[j].Key
+	})
+	return conflicts
+}
+
+// FormatEnvConflictError builds a multi-line error message that lists every conflicting
+// key (without its value, to avoid leaking secrets like ANTHROPIC_AUTH_TOKEN) and tells
+// the user exactly how to fix the conflict themselves. ccc deliberately does not auto-fix
+// settings.json — configuration conflicts are the user's responsibility.
+//
+// Returns an empty string when conflicts is empty so callers can treat that as "no error".
+func FormatEnvConflictError(settingsPath, configPath string, conflicts []EnvConflict) string {
+	if len(conflicts) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("settings.json env conflicts with provider configuration:\n")
+	b.WriteString(fmt.Sprintf("  file: %s\n", settingsPath))
+	b.WriteString("  conflicting keys:\n")
+	for _, c := range conflicts {
+		b.WriteString(fmt.Sprintf("    - %s  (%s)\n", c.Key, c.Reason))
+	}
+	b.WriteString("\nWhy this is a problem:\n")
+	b.WriteString("  Claude Code's settings.json \"env\" field overrides environment variables\n")
+	b.WriteString("  passed by ccc when launching claude. The keys above would silently override\n")
+	b.WriteString("  the provider env that ccc passes via command line, causing the provider\n")
+	b.WriteString("  switch to use the wrong base_url / token / model.\n")
+	b.WriteString("\nHow to fix:\n")
+	b.WriteString(fmt.Sprintf("  1. Remove the keys above from the \"env\" field in %s.\n", settingsPath))
+	b.WriteString(fmt.Sprintf("  2. Put provider-related config under providers.<name>.env in %s instead.\n", configPath))
+	b.WriteString("  ccc will refuse to start claude until this conflict is resolved.\n")
+	return b.String()
+}

--- a/internal/config/env_guard_test.go
+++ b/internal/config/env_guard_test.go
@@ -1,0 +1,236 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// sortConflicts returns the conflict keys sorted, used for deterministic comparison.
+func sortConflicts(conflicts []EnvConflict) []EnvConflict {
+	sorted := make([]EnvConflict, len(conflicts))
+	copy(sorted, conflicts)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Key < sorted[j].Key
+	})
+	return sorted
+}
+
+func TestDetectSettingsEnvConflicts(t *testing.T) {
+	tests := []struct {
+		name           string
+		userSettings   map[string]interface{}
+		managedEnvKeys map[string]bool
+		wantKeys       []string          // expected keys (sorted)
+		wantReasons    map[string]string // expected reasons keyed by conflict key (substring match)
+	}{
+		{
+			name:           "nil userSettings returns nil",
+			userSettings:   nil,
+			managedEnvKeys: map[string]bool{"X": true},
+			wantKeys:       nil,
+		},
+		{
+			name:           "no env field returns nil",
+			userSettings:   map[string]interface{}{"permissions": map[string]interface{}{}},
+			managedEnvKeys: map[string]bool{"X": true},
+			wantKeys:       nil,
+		},
+		{
+			name: "non-conflicting custom var returns nil",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"MY_CUSTOM_VAR": "value",
+				},
+			},
+			managedEnvKeys: map[string]bool{},
+			wantKeys:       nil,
+		},
+		{
+			name: "ANTHROPIC_BASE_URL detected as prefix",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"ANTHROPIC_BASE_URL": "https://example.com",
+				},
+			},
+			managedEnvKeys: map[string]bool{},
+			wantKeys:       []string{"ANTHROPIC_BASE_URL"},
+			wantReasons: map[string]string{
+				"ANTHROPIC_BASE_URL": "prefix",
+			},
+		},
+		{
+			name: "CLAUDE_CODE_MAX_OUTPUT_TOKENS detected as prefix",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "8192",
+				},
+			},
+			managedEnvKeys: map[string]bool{},
+			wantKeys:       []string{"CLAUDE_CODE_MAX_OUTPUT_TOKENS"},
+			wantReasons: map[string]string{
+				"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "prefix",
+			},
+		},
+		{
+			name: "non-prefix managed key hits managed reason",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"API_TIMEOUT": "30000",
+				},
+			},
+			managedEnvKeys: map[string]bool{"API_TIMEOUT": true},
+			wantKeys:       []string{"API_TIMEOUT"},
+			wantReasons: map[string]string{
+				"API_TIMEOUT": "managed",
+			},
+		},
+		{
+			name: "mixed: prefix + custom (allowed) + managed",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"ANTHROPIC_MODEL": "claude-3",
+					"MY_CUSTOM_VAR":   "value",
+					"API_TIMEOUT":     "30000",
+				},
+			},
+			managedEnvKeys: map[string]bool{"API_TIMEOUT": true},
+			wantKeys:       []string{"ANTHROPIC_MODEL", "API_TIMEOUT"},
+			wantReasons: map[string]string{
+				"ANTHROPIC_MODEL": "prefix",
+				"API_TIMEOUT":     "managed",
+			},
+		},
+		{
+			name: "prefix is strict: MYANTHROPIC_X not a hit",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"MYANTHROPIC_X": "x",
+					"ANTHROPIC_":    "edge",
+					"CLAUDE_":       "edge",
+				},
+			},
+			managedEnvKeys: map[string]bool{},
+			wantKeys:       []string{"ANTHROPIC_", "CLAUDE_"},
+			wantReasons: map[string]string{
+				"ANTHROPIC_": "prefix",
+				"CLAUDE_":    "prefix",
+			},
+		},
+		{
+			name: "env is not a map returns nil",
+			userSettings: map[string]interface{}{
+				"env": "not a map",
+			},
+			managedEnvKeys: map[string]bool{},
+			wantKeys:       nil,
+		},
+		{
+			name: "ANTHROPIC_BASE_URL also in managed: still reports as prefix",
+			userSettings: map[string]interface{}{
+				"env": map[string]interface{}{
+					"ANTHROPIC_BASE_URL": "x",
+				},
+			},
+			managedEnvKeys: map[string]bool{"ANTHROPIC_BASE_URL": true},
+			wantKeys:       []string{"ANTHROPIC_BASE_URL"},
+			wantReasons: map[string]string{
+				"ANTHROPIC_BASE_URL": "prefix",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectSettingsEnvConflicts(tt.userSettings, tt.managedEnvKeys)
+			if len(tt.wantKeys) == 0 {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+
+			if len(got) != len(tt.wantKeys) {
+				t.Fatalf("conflict count = %d, want %d (got: %+v)", len(got), len(tt.wantKeys), got)
+			}
+
+			sortedGot := sortConflicts(got)
+			for i, key := range tt.wantKeys {
+				if sortedGot[i].Key != key {
+					t.Errorf("conflict[%d].Key = %q, want %q", i, sortedGot[i].Key, key)
+				}
+				if want, ok := tt.wantReasons[key]; ok {
+					if !strings.Contains(strings.ToLower(sortedGot[i].Reason), want) {
+						t.Errorf("conflict[%s].Reason = %q, want it to contain %q", key, sortedGot[i].Reason, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFormatEnvConflictError(t *testing.T) {
+	settingsPath := "/home/user/.claude/settings.json"
+	configPath := "/home/user/.claude/ccc.json"
+
+	t.Run("error contains all conflict keys", func(t *testing.T) {
+		conflicts := []EnvConflict{
+			{Key: "ANTHROPIC_BASE_URL", Reason: "anthropic/claude prefix"},
+			{Key: "API_TIMEOUT", Reason: "managed by provider/base"},
+		}
+		msg := FormatEnvConflictError(settingsPath, configPath, conflicts)
+
+		for _, key := range []string{"ANTHROPIC_BASE_URL", "API_TIMEOUT"} {
+			if !strings.Contains(msg, key) {
+				t.Errorf("error message should contain key %q, got:\n%s", key, msg)
+			}
+		}
+	})
+
+	t.Run("error does not contain any value (secret redaction)", func(t *testing.T) {
+		conflicts := []EnvConflict{
+			{Key: "ANTHROPIC_AUTH_TOKEN", Reason: "anthropic/claude prefix"},
+		}
+		msg := FormatEnvConflictError(settingsPath, configPath, conflicts)
+
+		// Common patterns that would indicate value leak
+		forbiddenSubstrings := []string{
+			"sk-",      // typical token prefix
+			"Bearer ",  // header form
+			"https://", // URL form (would leak base url)
+		}
+		for _, bad := range forbiddenSubstrings {
+			if strings.Contains(msg, bad) {
+				t.Errorf("error message must not contain %q (value leak risk), got:\n%s", bad, msg)
+			}
+		}
+	})
+
+	t.Run("error contains both paths and remediation guidance", func(t *testing.T) {
+		conflicts := []EnvConflict{
+			{Key: "ANTHROPIC_MODEL", Reason: "anthropic/claude prefix"},
+		}
+		msg := FormatEnvConflictError(settingsPath, configPath, conflicts)
+
+		// Must include settings.json path
+		if !strings.Contains(msg, settingsPath) {
+			t.Errorf("error message should reference settings path %q, got:\n%s", settingsPath, msg)
+		}
+		// Must reference ccc.json (so users know where to put provider config)
+		if !strings.Contains(msg, configPath) {
+			t.Errorf("error message should reference config path %q, got:\n%s", configPath, msg)
+		}
+		// Must explain WHY (provider switch failure)
+		lowered := strings.ToLower(msg)
+		if !strings.Contains(lowered, "provider") {
+			t.Errorf("error message should explain why (mention provider), got:\n%s", msg)
+		}
+	})
+
+	t.Run("empty conflicts returns empty string", func(t *testing.T) {
+		msg := FormatEnvConflictError(settingsPath, configPath, nil)
+		if msg != "" {
+			t.Errorf("expected empty string for nil conflicts, got: %q", msg)
+		}
+	})
+}


### PR DESCRIPTION
## 背景

实测验证（claude 2.1.144，隔离环境三组对照实验，详见 \`docs/discuss-20260519-env-priority.md\`）确认：

**Claude Code 中 \`~/.claude/settings.json\` 的 \`env\` 字段严格覆盖 claude 进程继承的 OS 环境变量。**

ccc 通过 \`syscall.Exec\` 把 provider env 作为进程环境变量传给 claude（\`internal/cli/exec.go\`），其优先级**低于** settings.json 的 env。因此只要 settings.json 的 \`env\` 里残留 \`ANTHROPIC_*\`/\`CLAUDE_*\` 或与 provider/base 同名的 key，就会**覆盖 ccc 传入的 provider 配置，导致切换 provider 静默失效**。

当前 main（#76 \`FilterUserEnvForSettings\`）的做法是**静默剥离**这些 key 后继续运行——会丢失用户手动配置且无任何提示。

## 改动

ccc 不再尝试自动剥离/迁移/修改用户 settings.json。检测到冲突就**直接报错并中止**，无交互、无 y/N，交互与非交互行为一致。\`ccc validate\` 同样做检测。

冲突判据：
- key 以 \`ANTHROPIC_\` 或 \`CLAUDE_\` 开头，**或**
- key 与 base / provider env 同名（managed key）。

报错文本**只列 key，不列 value**（避免 AUTH_TOKEN 打到终端/CI 日志），并打印 settings.json / ccc.json 路径与修复指引。

## 文件

- 新增 \`internal/config/env_guard.go\`：\`EnvConflict\`、\`DetectSettingsEnvConflicts\`、\`FormatEnvConflictError\`
- 新增 \`internal/config/env_guard_test.go\`：表驱动检测与脱敏断言测试
- 新增 \`internal/cli/exec_test.go\`：runClaude / runValidate 路径集成测试
- 修改 \`internal/cli/exec.go\`：\`runClaude\` 在 \`SwitchWithHook\` 前插入守卫
- 修改 \`internal/cli/cli.go\`：\`runValidate\` 在 \`validate.Run\` 前插入守卫，\`--all\` / 单 provider 范围正确处理
- 更新 \`README.md\` / \`README-CN.md\` / \`docs/settings-merge-strategy.md\`：从"自动剥离"改为"硬守卫报错"
- 提交讨论日志 \`docs/discuss-20260519-env-priority.md\`

## 破坏性变化

原本"settings.json 有 \`ANTHROPIC_*\` → 静默剥离后照常启动"，现在变为"报错中止，要求用户先清理 settings.json"。

修复方法：从 \`~/.claude/settings.json\` 的 \`env\` 中删除冲突 key，并把 provider 相关配置改到 \`~/.claude/ccc.json\` 的 \`providers.<name>.env\`。

## 验证

- \`./check.sh\` 全绿（lint + race test + build）
- 手工冒烟（隔离环境 \`CCC_CONFIG_DIR=./tmp/x\`，未污染真实配置）：
  - \`ccc glm\` 冲突 → 报错列 key 不列 value、退出码非 0、未启动 claude
  - \`ccc validate\` / \`ccc validate --all\` 冲突 → 同样报错中止
  - \`ccc glm -p\` 非交互场景 → 同样报错退出，无阻塞、无 stdin 读取
  - 移除冲突 key 后回归正常流程
  - \`md5sum\` 比对：守卫拒绝前后 settings.json 文件内容比特一致（证明 ccc 不修改用户文件）

## 不在本次范围

- 不做任何 env 迁移到 ccc.json
- 不删除 \`FilterUserEnvForSettings\` / \`MergeWithPriority\`（守卫命中即中止；未命中时既有逻辑不变，对无冲突输入是恒等行为）