### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-05-20
 
 ### Removed
 
-- Supervisor mode (replaced by Claude Code's built-in goal and loop functionality)
+- **BREAKING**: Supervisor mode (replaced by Claude Code's built-in goal and loop functionality)
   - Removed all supervisor-related code, tests, config, and dependencies
-  - Removed supervisor-hook and supervisor-mode CLI commands
-  - Removed slash command files (supervisor.md, supervisoroff.md)
+  - Removed `supervisor-hook` and `supervisor-mode` CLI commands
+  - Removed slash command files (`supervisor.md`, `supervisoroff.md`)
   - Project rebranded as "Claude Code Configuration Switcher"
+
+### Added
+
+- **Hard guard for settings.json env conflicts**: detect and reject conflicts between
+  provider env vars and user-defined env in settings.json to prevent silent overrides
 
 ### Changed
 
 - Streamlined README/README-CN: trimmed the Configuration Merge Strategy section
-  and removed leftover Supervisor references now that supervisor mode is gone.
+  and removed leftover Supervisor references now that supervisor mode is gone
+
+## [0.3.3] - 2026-03-26
+
+### Fixed
+
+- Preserve user-defined env in `settings.json` when switching providers (#76)
+
+## [0.3.2] - 2026-02-24
+
+### Added
+
+- **Settings merge strategy**: preserve user-defined config in `settings.json`
+  when switching providers instead of overwriting (#73)
+- Documentation of configuration merge strategy in README and README-CN
+
+### Changed
+
+- Reverted PreToolUse hook integration to keep CLI behavior simple (#69)
+- Simplified README-CN for better user experience
+- Updated `CLAUDE.md` with simplified development process
+
+### Removed
+
+- SpecKit-related files and configuration (#70)
+- PreToolUse hook related code, tests, and configuration
+
+### Fixed
+
+- Handle slices in `deepCopy` and add a timeout constant in config merging
+
+## [0.3.1] - 2026-01-19
+
+### Fixed
+
+- Make `supervisor-mode` command silent when setting the mode (#65)
+- Environment variable precedence issue (#63)
+- Add beta headers for `validate` command to support all providers (#64)
 
 ## [0.3.0] - 2026-01-16
 
@@ -90,6 +132,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repositioned project as "Claude Code Supervisor"
 - Repository renamed from `claude-code-config-switcher` to `claude-code-supervisor`
 
+[0.4.0]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.3...v0.4.0
+[0.3.3]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/guyskk/claude-code-supervisor/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/guyskk/claude-code-supervisor/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/guyskk/claude-code-supervisor/releases/tag/v0.2.0


### PR DESCRIPTION
## Release 0.4.0

### Changelog 更新

- 新增 0.4.0 条目（2026-05-20）
  - **Breaking**: 移除 Supervisor 模式（由 Claude Code 内置的 goal/loop 功能替代）
  - 新增 settings.json env 冲突硬守卫
  - 精简 README/README-CN
- 补全此前未记录的 0.3.1 / 0.3.2 / 0.3.3 条目（从 git 历史回填）

### 发布流程

合并此 PR 后，将在 main 上打 `v0.4.0` 标签并推送。