### PR TITLE
chore: update repo URL refs to claude-code-config-switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed `supervisor-hook` and `supervisor-mode` CLI commands
   - Removed slash command files (`supervisor.md`, `supervisoroff.md`)
   - Project rebranded as "Claude Code Configuration Switcher"
+  - Repository renamed back to `claude-code-config-switcher` (GitHub redirects the old URL)
 
 ### Added
 
@@ -132,10 +133,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repositioned project as "Claude Code Supervisor"
 - Repository renamed from `claude-code-config-switcher` to `claude-code-supervisor`
 
-[0.4.0]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.3...v0.4.0
-[0.3.3]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.2...v0.3.3
-[0.3.2]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.1...v0.3.2
-[0.3.1]: https://github.com/guyskk/claude-code-supervisor/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/guyskk/claude-code-supervisor/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/guyskk/claude-code-supervisor/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/guyskk/claude-code-supervisor/releases/tag/v0.2.0
+[0.4.0]: https://github.com/guyskk/claude-code-config-switcher/compare/v0.3.3...v0.4.0
+[0.3.3]: https://github.com/guyskk/claude-code-config-switcher/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/guyskk/claude-code-config-switcher/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/guyskk/claude-code-config-switcher/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/guyskk/claude-code-config-switcher/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/guyskk/claude-code-config-switcher/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/guyskk/claude-code-config-switcher/releases/tag/v0.2.0

--- a/README-CN.md
+++ b/README-CN.md
@@ -13,10 +13,10 @@
 #### 选项 A：一键安装（Linux / macOS）
 
 ```bash
-OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); curl -LO "https://github.com/guyskk/claude-code-supervisor/releases/latest/download/ccc-${OS}-${ARCH}" && sudo install -m 755 "ccc-${OS}-${ARCH}" /usr/local/bin/ccc && rm "ccc-${OS}-${ARCH}" && ccc --version
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); curl -LO "https://github.com/guyskk/claude-code-config-switcher/releases/latest/download/ccc-${OS}-${ARCH}" && sudo install -m 755 "ccc-${OS}-${ARCH}" /usr/local/bin/ccc && rm "ccc-${OS}-${ARCH}" && ccc --version
 ```
 
-#### 选项 B：从 [Releases](https://github.com/guyskk/claude-code-supervisor/releases) 下载
+#### 选项 B：从 [Releases](https://github.com/guyskk/claude-code-config-switcher/releases) 下载
 
 下载适合你平台的二进制文件（`ccc-darwin-arm64`、`ccc-linux-amd64` 等）并安装到 `/usr/local/bin/`。
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 #### Option A: One-line install (Linux / macOS)
 
 ```bash
-OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); curl -LO "https://github.com/guyskk/claude-code-supervisor/releases/latest/download/ccc-${OS}-${ARCH}" && sudo install -m 755 "ccc-${OS}-${ARCH}" /usr/local/bin/ccc && rm "ccc-${OS}-${ARCH}" && ccc --version
+OS=$(uname -s | tr '[:upper:]' '[:lower:]'); ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); curl -LO "https://github.com/guyskk/claude-code-config-switcher/releases/latest/download/ccc-${OS}-${ARCH}" && sudo install -m 755 "ccc-${OS}-${ARCH}" /usr/local/bin/ccc && rm "ccc-${OS}-${ARCH}" && ccc --version
 ```
 
-#### Option B: Download from [Releases](https://github.com/guyskk/claude-code-supervisor/releases)
+#### Option B: Download from [Releases](https://github.com/guyskk/claude-code-config-switcher/releases)
 
 Download the binary for your platform (`ccc-darwin-arm64`, `ccc-linux-amd64`, etc.) and install to `/usr/local/bin/`.
 

--- a/docs/discuss-20260519-env-priority.md
+++ b/docs/discuss-20260519-env-priority.md
@@ -2,7 +2,7 @@
 
 日期：2026-05-19
 话题：核实 ccc 切换 provider 时 env 的生效优先级，评估 PR #79 的方案是否安全。
-触发：https://github.com/guyskk/claude-code-supervisor/pull/79
+触发：https://github.com/guyskk/claude-code-config-switcher/pull/79
 
 > 本文件 Append-only，只追加不覆盖。
 

--- a/docs/supervisor-mode-improvement-proposal.md
+++ b/docs/supervisor-mode-improvement-proposal.md
@@ -940,7 +940,7 @@ setup_tmux_monitor() {
 
 - Ralph 项目：https://github.com/anthropics/ralph-claude-code
 - Claude Code Hooks 文档：https://docs.anthropic.com/en/docs/build-with-claude/claude-for-developers
-- 当前项目：https://github.com/guyskk/claude-code-supervisor
+- 当前项目：https://github.com/guyskk/claude-code-config-switcher
 
 ---
 


### PR DESCRIPTION
## 背景

仓库已重命名 `claude-code-supervisor` → `claude-code-config-switcher`，同步更新代码库中的 URL 引用。

## 修改内容

- **README.md / README-CN.md**: 安装命令和 Releases 链接更新到新 repo URL
- **CHANGELOG.md**:
  - 底部 compare 链接全部更新
  - 0.4.0 条目补充 `Repository renamed back to claude-code-config-switcher` 说明
- **docs/discuss-20260519-env-priority.md**: PR #79 链接更新
- **docs/supervisor-mode-improvement-proposal.md**: 项目链接更新

## 保留不动（历史记录）

- `CHANGELOG.md` 第 134 行 0.2.0 条目中的 `Repository renamed from claude-code-config-switcher to claude-code-supervisor` —— 这是当时的历史事实
- `docs/LLM_JSON_PARSER_IMPLEMENTATION_PLAN.md` 中的旧本地路径和当时的 module 名 —— 属于冻结的历史 plan 快照

## 验证

- Lint 通过
- 已搜索全仓库 `claude-code-supervisor` 残留，仅保留上述两处历史记录