### PR TITLE
fix: override stale ANTHROPIC_*/CLAUDE_* keys in settings.json via --settings

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -144,21 +144,47 @@ func filterEnvVars(env []string, shouldKeep func(string) bool) []string {
 
 // buildProviderSettingsJSON serializes provider env into a JSON string
 // suitable for passing to claude --settings.
+//
+// It also loads settings.json to detect ANTHROPIC_*/CLAUDE_* keys that the
+// provider does not define, and sets them to empty string in the --settings JSON.
+// This prevents stale values in settings.json (e.g. ANTHROPIC_MODEL from a
+// previous provider) from leaking into the current session.
+//
 // Environment variable references like ${VAR} are expanded before serialization.
-// Returns empty string if providerEnv is nil or empty.
+// Returns empty string if the resulting env map is empty.
 func buildProviderSettingsJSON(providerEnv map[string]interface{}) (string, error) {
 	if len(providerEnv) == 0 {
 		return "", nil
 	}
 
-	// Expand env var references
-	expanded := make(map[string]interface{}, len(providerEnv))
+	// Start with provider env, expanding ${VAR} references
+	settingsEnv := make(map[string]interface{}, len(providerEnv))
 	for k, v := range providerEnv {
-		expanded[k] = os.ExpandEnv(fmt.Sprintf("%v", v))
+		settingsEnv[k] = os.ExpandEnv(fmt.Sprintf("%v", v))
+	}
+
+	// Load settings.json to detect potential conflict keys.
+	// For any ANTHROPIC_*/CLAUDE_* key in settings.json that the provider does NOT
+	// define, set it to empty string in --settings to prevent stale values from
+	// leaking into the session (e.g. ANTHROPIC_MODEL from a previous provider).
+	userSettings, err := config.LoadSettings()
+	if err == nil && userSettings != nil {
+		userEnvMap := config.GetEnv(userSettings)
+		for key := range userEnvMap {
+			if strings.HasPrefix(key, "ANTHROPIC_") || strings.HasPrefix(key, "CLAUDE_") {
+				if _, providerHasKey := settingsEnv[key]; !providerHasKey {
+					settingsEnv[key] = ""
+				}
+			}
+		}
+	}
+
+	if len(settingsEnv) == 0 {
+		return "", nil
 	}
 
 	settings := map[string]interface{}{
-		"env": expanded,
+		"env": settingsEnv,
 	}
 	data, err := json.Marshal(settings)
 	if err != nil {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -101,6 +101,9 @@ func TestBuildProviderSettingsJSON(t *testing.T) {
 }
 
 func TestBuildProviderSettingsJSON_ExpandsEnvVars(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
 	// Set a test env var
 	t.Setenv("CCC_TEST_BASE_URL", "https://expanded.example.com")
 
@@ -122,5 +125,107 @@ func TestBuildProviderSettingsJSON_ExpandsEnvVars(t *testing.T) {
 	got := envResult["ANTHROPIC_BASE_URL"].(string)
 	if got != "https://expanded.example.com" {
 		t.Errorf("expected env var to be expanded, got: %s", got)
+	}
+}
+
+func TestBuildProviderSettingsJSON_OverridesStaleKeys(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	// settings.json has model keys from a previous provider
+	writeSettingsJSON(t, `{
+		"env": {
+			"ANTHROPIC_MODEL": "mimo-v2.5-pro[1m]",
+			"ANTHROPIC_DEFAULT_HAIKU_MODEL": "mimo-v2.5[1m]",
+			"ANTHROPIC_DEFAULT_OPUS_MODEL": "mimo-v2.5-pro[1m]",
+			"ANTHROPIC_DEFAULT_SONNET_MODEL": "mimo-v2.5-pro[1m]",
+			"ANTHROPIC_AUTH_TOKEN": "old-token",
+			"MY_CUSTOM_VAR": "keep-me"
+		}
+	}`)
+
+	// Provider only defines AUTH_TOKEN and BASE_URL (like tokenswitch)
+	providerEnv := map[string]interface{}{
+		"ANTHROPIC_AUTH_TOKEN": "new-token",
+		"ANTHROPIC_BASE_URL":   "https://example.com",
+	}
+
+	result, err := buildProviderSettingsJSON(providerEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	envMap := parsed["env"].(map[string]interface{})
+
+	// Provider keys should have provider values
+	if envMap["ANTHROPIC_AUTH_TOKEN"] != "new-token" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %v, want new-token", envMap["ANTHROPIC_AUTH_TOKEN"])
+	}
+	if envMap["ANTHROPIC_BASE_URL"] != "https://example.com" {
+		t.Errorf("ANTHROPIC_BASE_URL = %v, want https://example.com", envMap["ANTHROPIC_BASE_URL"])
+	}
+
+	// Stale model keys should be overridden to empty string
+	if envMap["ANTHROPIC_MODEL"] != "" {
+		t.Errorf("ANTHROPIC_MODEL = %v, want empty string", envMap["ANTHROPIC_MODEL"])
+	}
+	if envMap["ANTHROPIC_DEFAULT_HAIKU_MODEL"] != "" {
+		t.Errorf("ANTHROPIC_DEFAULT_HAIKU_MODEL = %v, want empty string", envMap["ANTHROPIC_DEFAULT_HAIKU_MODEL"])
+	}
+	if envMap["ANTHROPIC_DEFAULT_OPUS_MODEL"] != "" {
+		t.Errorf("ANTHROPIC_DEFAULT_OPUS_MODEL = %v, want empty string", envMap["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+	}
+	if envMap["ANTHROPIC_DEFAULT_SONNET_MODEL"] != "" {
+		t.Errorf("ANTHROPIC_DEFAULT_SONNET_MODEL = %v, want empty string", envMap["ANTHROPIC_DEFAULT_SONNET_MODEL"])
+	}
+
+	// Non-ANTHROPIC/CLAUDE keys should NOT be in --settings
+	if _, exists := envMap["MY_CUSTOM_VAR"]; exists {
+		t.Error("MY_CUSTOM_VAR should not be in --settings (not ANTHROPIC_*/CLAUDE_*)")
+	}
+}
+
+func TestBuildProviderSettingsJSON_ProviderOverridesNotNulled(t *testing.T) {
+	cleanup := setupTestDir(t)
+	defer cleanup()
+
+	// settings.json has model keys
+	writeSettingsJSON(t, `{
+		"env": {
+			"ANTHROPIC_MODEL": "old-model",
+			"ANTHROPIC_BASE_URL": "http://old"
+		}
+	}`)
+
+	// Provider defines ALL keys — should NOT be set to empty
+	providerEnv := map[string]interface{}{
+		"ANTHROPIC_AUTH_TOKEN": "new-token",
+		"ANTHROPIC_BASE_URL":   "https://new.example.com",
+		"ANTHROPIC_MODEL":      "new-model",
+	}
+
+	result, err := buildProviderSettingsJSON(providerEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	envMap := parsed["env"].(map[string]interface{})
+
+	// Provider values should win, not empty string
+	if envMap["ANTHROPIC_MODEL"] != "new-model" {
+		t.Errorf("ANTHROPIC_MODEL = %v, want new-model", envMap["ANTHROPIC_MODEL"])
+	}
+	if envMap["ANTHROPIC_BASE_URL"] != "https://new.example.com" {
+		t.Errorf("ANTHROPIC_BASE_URL = %v, want https://new.example.com", envMap["ANTHROPIC_BASE_URL"])
 	}
 }


### PR DESCRIPTION
## Problem

When a provider doesn't define certain ANTHROPIC_\*/CLAUDE_\* keys (e.g. ANTHROPIC_MODEL), stale values from a previous provider in settings.json leak into the session and cause errors.

Example: settings.json has ANTHROPIC_MODEL=mimo-v2.5-pro[1m] from mimotpro provider. Switching to tokenswitch (which only defines AUTH_TOKEN and BASE_URL) causes Claude to use the wrong model.

## Fix

In buildProviderSettingsJSON(), load settings.json and for any ANTHROPIC_\*/CLAUDE_\* key that the provider does NOT define, set it to empty string in the --settings JSON. This overrides the stale value while letting Claude Code fall back to its defaults.

## Verification

- ANTHROPIC_MODEL set to empty string → Claude uses default model (no error) ✅
- Provider-defined keys (AUTH_TOKEN, BASE_URL) still override settings.json ✅
- Non-ANTHROPIC/CLAUDE keys (MY_CUSTOM_VAR) preserved from settings.json ✅
- All tests pass ✅